### PR TITLE
fix: add explicit ESM import extensions

### DIFF
--- a/api/cron/due-today.ts
+++ b/api/cron/due-today.ts
@@ -2,7 +2,7 @@
 // api/cron/due-today.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
-import { sendMail } from "../../lib/mail";
+import { sendMail } from "../../lib/mail.js";
 
 const url = process.env.SUPABASE_URL!;
 const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;

--- a/api/cron/heads-up.ts
+++ b/api/cron/heads-up.ts
@@ -2,7 +2,7 @@
 // api/cron/heads-up.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
-import { sendMail } from "../../lib/mail";
+import { sendMail } from "../../lib/mail.js";
 
 const url = process.env.SUPABASE_URL!;
 const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;

--- a/api/cron/price-watch.ts
+++ b/api/cron/price-watch.ts
@@ -1,9 +1,9 @@
 // api/cron/price-watch.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
-import { extractPriceCentsFromHtml } from "../../lib/price-parsers";
-import { previewDecision } from "../../lib/decision-engine";
-import { sendMail } from "../../lib/mail";
+import { extractPriceCentsFromHtml } from "../../lib/price-parsers.js";
+import { previewDecision } from "../../lib/decision-engine.js";
+import { sendMail } from "../../lib/mail.js";
 
 const url = process.env.SUPABASE_URL!;
 const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;

--- a/api/dev/send-test.ts
+++ b/api/dev/send-test.ts
@@ -1,5 +1,5 @@
 // api/dev/send-test.ts
-import { sendEmail } from "../../lib/postmark";
+import { sendEmail } from "../../lib/postmark.js";
 
 export default async function handler(req: any, res: any) {
   const to = (req.query?.to as string) || process.env.EMAIL_FROM;

--- a/api/policy/preview.ts
+++ b/api/policy/preview.ts
@@ -1,7 +1,7 @@
 // api/policy/preview.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
-import { previewDecision } from "../../lib/decision-engine";
+import { previewDecision } from "../../lib/decision-engine.js";
 
 const url = process.env.SUPABASE_URL!;
 const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;

--- a/api/price-check.ts
+++ b/api/price-check.ts
@@ -1,8 +1,8 @@
 // api/price-check.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
-import { previewDecision } from "../lib/decision-engine";
-import { sendMail } from "../lib/mail";
+import { previewDecision } from "../lib/decision-engine.js";
+import { sendMail } from "../lib/mail.js";
 
 const url = process.env.SUPABASE_URL!;
 const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;

--- a/lib/api/admin/ingest-pdf.ts
+++ b/lib/api/admin/ingest-pdf.ts
@@ -1,7 +1,7 @@
 // api/admin/ingest-pdf.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
-import { parseHmPdf } from "../../lib/pdf";
+import parseHmPdf from "../../pdf.js";
 
 export const config = { runtime: "nodejs18.x" }; // pdf-parse needs Node
 

--- a/lib/decision-engine.ts
+++ b/lib/decision-engine.ts
@@ -1,5 +1,5 @@
 // lib/decision-engine.ts
-import { getPolicy, type MerchantPolicy } from "./policies";
+import { getPolicy, type MerchantPolicy } from "./policies.js";
 
 export type ReceiptLite = {
   merchant: string | null;


### PR DESCRIPTION
## Summary
- ensure ESM-compatible imports by appending `.js` extensions across decision engine and API handlers
- correct H&M PDF admin import to use default export with proper relative path

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c202e60bc48331b1ed849af8110e46