### PR TITLE
fix: update runtime config

### DIFF
--- a/api/receipts/index.ts
+++ b/api/receipts/index.ts
@@ -3,7 +3,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
 
-export const config = { runtime: "nodejs" } as const;
+export const config = { runtime: "nodejs" };
 
 const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;


### PR DESCRIPTION
## Summary
- remove const assertion from receipts config

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)
- `npx tsc --noEmit` (fails: Cannot find type definition file for '@types/node')

------
https://chatgpt.com/codex/tasks/task_b_68c20f8483a483319e196a5228f65109