### PR TITLE
Specify Node runtime for cron handlers

### DIFF
--- a/api/cron/due-today.ts
+++ b/api/cron/due-today.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 // api/cron/due-today.ts
+export const config = { runtime: "nodejs" };
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
 import { sendMail } from "../../lib/mail.js";

--- a/api/cron/heads-up.ts
+++ b/api/cron/heads-up.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 // api/cron/heads-up.ts
+export const config = { runtime: "nodejs" };
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
 import { sendMail } from "../../lib/mail.js";

--- a/api/cron/price-watch.ts
+++ b/api/cron/price-watch.ts
@@ -1,4 +1,5 @@
 // api/cron/price-watch.ts
+export const config = { runtime: "nodejs" };
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
 import { extractPriceCentsFromHtml } from "../../lib/price-parsers.js";

--- a/api/cron/purge-inbound.ts
+++ b/api/cron/purge-inbound.ts
@@ -1,5 +1,6 @@
 // api/cron/purge-inbound.ts
 // Deletes inbound_emails older than 30 days. Safe 200 regardless (so cron doesn't thrash).
+export const config = { runtime: "nodejs" };
 
 import { createClient } from "@supabase/supabase-js";
 


### PR DESCRIPTION
## Summary
- declare Node runtime via `export const config` for all cron handlers

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68c20f9394208331af2728bfe28db10d