### PR TITLE
refactor: remove ts-nocheck directives

### DIFF
--- a/api/cron/due-today.ts
+++ b/api/cron/due-today.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // api/cron/due-today.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
@@ -18,17 +17,19 @@ export default async function handler(_req: VercelRequest, res: VercelResponse) 
     const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
     const todayGate = new Date(now.getTime() - 18 * 60 * 60 * 1000).toISOString();
 
+    type ReceiptRef = {
+      user_id: string | null;
+      merchant: string | null;
+      order_id: string | null;
+      purchase_date: string | null;
+      total_cents: number | null;
+    };
+
     type Row = {
       id: string;
       due_at: string;
       receipt_id: string | null;
-      receipts: {
-        user_id: string | null;
-        merchant: string | null;
-        order_id: string | null;
-        purchase_date: string | null;
-        total_cents: number | null;
-      } | null;
+      receipts: ReceiptRef | null;
     };
 
     // 1) Find due-today deadlines
@@ -46,25 +47,33 @@ export default async function handler(_req: VercelRequest, res: VercelResponse) 
     if (error) throw error;
 
     // 2) Resolve emails for the unique user_ids
-    const userIds = Array.from(new Set((data ?? [])
-      .map(r => (r as any).receipts?.user_id)
-      .filter((x): x is string => !!x)));
+    const rows: Row[] = (data ?? []) as unknown as Row[];
+    const userIds = Array.from(
+      new Set(rows.map(r => r.receipts?.user_id).filter((x): x is string => !!x))
+    );
 
     const emails = new Map<string, string | null>();
     if (userIds.length) {
+      type ProfileRow = { id: string; email: string | null };
       const { data: profs, error: e2 } = await supabase
         .from("profiles")
         .select("id, email")
         .in("id", userIds);
       if (e2) throw e2;
-      for (const p of (profs ?? [])) emails.set((p as any).id, (p as any).email);
+      for (const p of (profs ?? []) as ProfileRow[]) emails.set(p.id, p.email);
     }
 
     // 3) Send
     let sent = 0;
-    for (const d of (data ?? []) as Row[]) {
-      const r = d.receipts ?? ({} as Row["receipts"]);
-      const userId = r?.user_id ?? null;
+    for (const d of rows) {
+      const r: ReceiptRef = d.receipts ?? {
+        user_id: null,
+        merchant: null,
+        order_id: null,
+        purchase_date: null,
+        total_cents: null,
+      };
+      const userId = r.user_id;
       const email = userId ? emails.get(userId) ?? null : null;
 
       // if no profile email, optionally fall back to NOTIFY_TO
@@ -76,13 +85,16 @@ export default async function handler(_req: VercelRequest, res: VercelResponse) 
       }
 
       const when = new Date(d.due_at);
-      const amount = typeof r?.total_cents === "number" ? `$${(r!.total_cents!/100).toFixed(2)}` : "";
+      const amount = typeof r.total_cents === "number" ? `$${(r.total_cents/100).toFixed(2)}` : "";
 
-      const subject = `Reminder: ${(r?.merchant ?? "your purchase")} return window ends ${when.toISOString().replace("T"," ").replace(".000Z","Z")}`;
+      const subject = `Reminder: ${(r.merchant ?? "your purchase")} return window ends ${when
+        .toISOString()
+        .replace("T"," ")
+        .replace(".000Z","Z")}`;
       const body =
 `Heads up!
 
-Your ${r?.merchant ?? "purchase"} from ${r?.purchase_date ?? "unknown"} ${amount ? `(${amount})` : ""}
+Your ${r.merchant ?? "purchase"} from ${r.purchase_date ?? "unknown"} ${amount ? `(${amount})` : ""}
 is approaching the return deadline.
 Deadline (UTC): ${when.toISOString().replace("T"," ").replace(".000Z","Z")}
 
@@ -99,7 +111,8 @@ Open Covrily to review and decide: return or keep.`;
     }
 
     return res.status(200).json({ ok: true, sent_today: sent, users_resolved: userIds.length });
-  } catch (e: any) {
-    return res.status(500).json({ ok: false, error: String(e?.message || e) });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return res.status(500).json({ ok: false, error: message });
   }
 }

--- a/api/cron/heads-up.ts
+++ b/api/cron/heads-up.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // api/cron/heads-up.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
@@ -20,11 +19,18 @@ export default async function handler(_req: VercelRequest, res: VercelResponse) 
     const day7start = startOfUTC(addDaysUTC(new Date(), 7)).toISOString();
     const day8start = startOfUTC(addDaysUTC(new Date(), 8)).toISOString();
 
+    type ReceiptRef = {
+      user_id: string | null;
+      merchant: string | null;
+      purchase_date: string | null;
+      total_cents: number | null;
+    };
+
     type Row = {
       id: string;
       due_at: string;
       receipt_id: string | null;
-      receipts: { user_id: string | null; merchant: string | null; purchase_date: string | null; total_cents: number | null } | null;
+      receipts: ReceiptRef | null;
     };
 
     const { data, error } = await supabase
@@ -41,20 +47,30 @@ export default async function handler(_req: VercelRequest, res: VercelResponse) 
     if (error) throw error;
 
     // resolve emails
-    const userIds = Array.from(new Set((data ?? [])
-      .map(r => (r as any).receipts?.user_id)
-      .filter((x): x is string => !!x)));
+    const rows: Row[] = (data ?? []) as unknown as Row[];
+    const userIds = Array.from(
+      new Set(rows.map(r => r.receipts?.user_id).filter((x): x is string => !!x))
+    );
     const emails = new Map<string, string | null>();
     if (userIds.length) {
-      const { data: profs, error: e2 } = await supabase.from("profiles").select("id, email").in("id", userIds);
+      type ProfileRow = { id: string; email: string | null };
+      const { data: profs, error: e2 } = await supabase
+        .from("profiles")
+        .select("id, email")
+        .in("id", userIds);
       if (e2) throw e2;
-      for (const p of (profs ?? [])) emails.set((p as any).id, (p as any).email);
+      for (const p of (profs ?? []) as ProfileRow[]) emails.set(p.id, p.email);
     }
 
     let sent = 0;
-    for (const d of (data ?? []) as Row[]) {
-      const r = d.receipts ?? ({} as Row["receipts"]);
-      const userId = r?.user_id ?? null;
+    for (const d of rows) {
+      const r: ReceiptRef = d.receipts ?? {
+        user_id: null,
+        merchant: null,
+        purchase_date: null,
+        total_cents: null,
+      };
+      const userId = r.user_id;
       const email = userId ? emails.get(userId) ?? null : null;
 
       const to = email || (useFallback ? fallbackTo : "");
@@ -64,17 +80,16 @@ export default async function handler(_req: VercelRequest, res: VercelResponse) 
       }
 
       const when = new Date(d.due_at);
-      const amount = typeof r?.total_cents === "number" ? `$${(r!.total_cents!/100).toFixed(2)}` : "";
+      const amount = typeof r.total_cents === "number" ? `$${(r.total_cents/100).toFixed(2)}` : "";
 
-      const subject = `Heads-up: ${(r?.merchant || "purchase")} return deadline in ~7 days`;
+      const subject = `Heads-up: ${(r.merchant || "purchase")} return deadline in ~7 days`;
       const body =
 `Friendly reminder!
 
-Your ${r?.merchant ?? "purchase"} from ${r?.purchase_date ?? "unknown"} ${amount ? `(${amount})` : ""}
+Your ${r.merchant ?? "purchase"} from ${r.purchase_date ?? "unknown"} ${amount ? `(${amount})` : ""}
 has a return deadline on ${when.toISOString().replace("T"," ").replace(".000Z","Z")} (in ~7 days).
 
 Open Covrily to review and decide: return or keep.`;
-
       await sendMail(to, subject, body, { debugRouteTo: email || null });
 
       await supabase
@@ -86,7 +101,8 @@ Open Covrily to review and decide: return or keep.`;
     }
 
     return res.status(200).json({ ok: true, processed: sent, users_resolved: userIds.length });
-  } catch (e: any) {
-    return res.status(500).json({ ok: false, error: String(e?.message || e) });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return res.status(500).json({ ok: false, error: message });
   }
 }

--- a/api/me/summary.ts
+++ b/api/me/summary.ts
@@ -1,27 +1,33 @@
-// @ts-nocheck
+import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
 
-export default async function handler(req: any, res: any) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const user = (req.query.user as string) || "";
-  if (!user) return res.status(400).json({ ok:false, error:"missing user" });
+  if (!user) return res.status(400).json({ ok: false, error: "missing user" });
 
   const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  const [{ data: rc }, { data: dl }] = await Promise.all([
+  type ReceiptRow = { id: string };
+  type DeadlineRow = { id: string; status: string | null; decision: string | null };
+
+  const [{ data: rcRaw }, { data: dlRaw }] = await Promise.all([
     supabase.from("receipts").select("id").eq("user_id", user),
-    supabase.from("deadlines").select("id, status").eq("user_id", user)
+    supabase.from("deadlines").select("id, status, decision").eq("user_id", user),
   ]);
 
-  const open = (dl||[]).filter(d=>d.status==='open').length;
-  const kept = (dl||[]).filter(d=>d.decision==='keep').length;
-  const returned = (dl||[]).filter(d=>d.decision==='return').length;
+  const rc = (rcRaw ?? []) as ReceiptRow[];
+  const dl = (dlRaw ?? []) as DeadlineRow[];
+
+  const open = dl.filter(d => d.status === "open").length;
+  const kept = dl.filter(d => d.decision === "keep").length;
+  const returned = dl.filter(d => d.decision === "return").length;
 
   res.status(200).json({
     ok: true,
     user,
-    receipts: (rc||[]).length,
-    deadlines: { open, kept, returned }
+    receipts: rc.length,
+    deadlines: { open, kept, returned },
   });
 }

--- a/api/receipts/index.ts
+++ b/api/receipts/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // api/receipts/index.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
@@ -23,14 +22,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
 
+  type ReceiptRow = {
+    id: string;
+    user_id: string | null;
+    merchant: string | null;
+    order_id: string | null;
+    purchase_date: string | null;
+    total_cents: number | null;
+    tax_cents: number | null;
+    shipping_cents: number | null;
+    currency: string | null;
+    raw_url: string | null;
+  };
+
   const { data, error } = await supabase
     .from("receipts")
-    .select("id,user_id,merchant,order_id,purchase_date,total_cents,tax_cents,shipping_cents,currency,raw_url")
+    .select(
+      "id,user_id,merchant,order_id,purchase_date,total_cents,tax_cents,shipping_cents,currency,raw_url"
+    )
     .eq("id", id)
     .maybeSingle();
 
   if (error) return res.status(500).json({ ok: false, error: error.message });
-  if (!data) return res.status(404).json({ ok: false, error: "not found" });
+  const receipt = data as ReceiptRow | null;
+  if (!receipt) return res.status(404).json({ ok: false, error: "not found" });
 
-  return res.status(200).json({ ok: true, receipt: data });
+  return res.status(200).json({ ok: true, receipt });
 }


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` directives from API handlers
- add explicit types for Supabase queries and error handling

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c20fa0161883319c5e0e6eb30b6803