### PR TITLE
chore: add indexes for deadlines and receipts

### DIFF
--- a/covrily-context-docs/add_indexes.sql
+++ b/covrily-context-docs/add_indexes.sql
@@ -1,0 +1,3 @@
+-- Create indexes to optimize deadline and receipt lookups
+CREATE INDEX IF NOT EXISTS deadlines_due_at_idx ON public.deadlines (user_id, status, due_at);
+CREATE INDEX IF NOT EXISTS receipts_id_user_idx ON public.receipts (id, user_id);


### PR DESCRIPTION
## Summary
- add SQL script to create indexes for deadlines and receipts tables

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json`
- `psql -c "CREATE INDEX deadlines_due_at_idx..."` *(fails: command not found)*
- `node -e ...` *(fails: Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY)*


------
https://chatgpt.com/codex/tasks/task_b_68c20faa057c833196abed35ed735855