### PR TITLE
Handle file-path attachments from Postmark

### DIFF
--- a/api/inbound/postmark.test.ts
+++ b/api/inbound/postmark.test.ts
@@ -1,44 +1,47 @@
 import test, { mock } from 'node:test';
 import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import fs from 'node:fs/promises';
+import os from 'node:os';
 
-// environment required by handler
 process.env.SUPABASE_URL = 'http://example.com';
 process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
 
-test('passes decoded PDF buffer to parseHmPdf', async () => {
-  const { createRequire } = await import('node:module');
-  const require = createRequire(import.meta.url);
+const require = createRequire(import.meta.url);
 
-  // stub pdf-parse before lib/pdf.js is imported
-  const pdfParsePath = require.resolve('pdf-parse');
-  const pdfParseSpy = mock.fn(async () => ({ text: '' }));
-  require.cache[pdfParsePath] = {
-    id: pdfParsePath,
-    filename: pdfParsePath,
-    loaded: true,
-    exports: pdfParseSpy
-  } as any;
+// stub pdf-parse so we can inspect the buffer passed to it
+const pdfParsePath = require.resolve('pdf-parse');
+const pdfParseSpy = mock.fn(async () => ({ text: '' }));
+require.cache[pdfParsePath] = {
+  id: pdfParsePath,
+  filename: pdfParsePath,
+  loaded: true,
+  exports: pdfParseSpy
+} as any;
 
-  const fakeSupabase = {
-    storage: { from: () => ({ upload: async () => ({ error: null }) }) },
-    from: () => ({
-      upsert: () => ({
-        select: () => ({
-          single: async () => ({ data: { id: 1 }, error: null })
-        })
+// stub supabase client
+const supabasePath = require.resolve('@supabase/supabase-js');
+const ModuleCtor = require('module');
+const supabaseStub = new ModuleCtor.Module(supabasePath);
+const fakeSupabase = {
+  storage: { from: () => ({ upload: async () => ({ error: null }) }) },
+  from: () => ({
+    upsert: () => ({
+      select: () => ({
+        single: async () => ({ data: { id: 1 }, error: null })
       })
     })
-  };
+  })
+};
+supabaseStub.exports = { createClient: () => fakeSupabase };
+supabaseStub.loaded = true;
+require.cache[supabasePath] = supabaseStub as any;
 
-  const supabasePath = require.resolve('@supabase/supabase-js');
-  const ModuleCtor = require('module');
-  const supabaseStub = new ModuleCtor.Module(supabasePath);
-  supabaseStub.exports = { createClient: () => fakeSupabase };
-  supabaseStub.loaded = true;
-  require.cache[supabasePath] = supabaseStub as any;
+const { default: handler } = await import('./postmark.js');
+const { default: parseHmPdf } = await import('../../lib/pdf.js');
 
-  await import('../../lib/pdf.js');
-  const { default: handler } = await import('./postmark.js');
+test('passes decoded PDF buffer to parseHmPdf', async () => {
+  pdfParseSpy.mock.resetCalls();
 
   const b64 = Buffer.from('fake pdf').toString('base64');
   const req: any = {
@@ -54,10 +57,7 @@ test('passes decoded PDF buffer to parseHmPdf', async () => {
       ]
     }
   };
-
-  const res: any = {
-    status() { return { json() { return null; } }; }
-  };
+  const res: any = { status() { return { json() { return null; } }; } };
 
   await handler(req, res);
 
@@ -65,14 +65,39 @@ test('passes decoded PDF buffer to parseHmPdf', async () => {
   const arg = (pdfParseSpy.mock.calls as any[])[0].arguments[0];
   assert.ok(Buffer.isBuffer(arg));
   assert.deepStrictEqual(arg, Buffer.from(b64, 'base64'));
-
-  mock.restoreAll();
-  delete require.cache[pdfParsePath];
-  delete require.cache[supabasePath];
 });
 
 test('parseHmPdf throws on empty input', async () => {
-  const { default: parseHmPdf } = await import('../../lib/pdf.js');
   await assert.rejects(() => parseHmPdf(undefined as any), /empty pdf buffer/);
+});
+
+test('reads attachment from file path when not base64', async () => {
+  pdfParseSpy.mock.resetCalls();
+
+  const tmpDir = await fs.mkdtemp(`${os.tmpdir()}/`);
+  const filePath = `${tmpDir}/test.pdf`;
+  await fs.writeFile(filePath, Buffer.from('fake pdf'));
+
+  const req: any = {
+    method: 'POST',
+    body: {
+      MailboxHash: 'user-123',
+      Attachments: [
+        {
+          ContentType: 'application/pdf',
+          Content: filePath,
+          Name: 'receipt.pdf'
+        }
+      ]
+    }
+  };
+  const res: any = { status() { return { json() { return null; } }; } };
+
+  await handler(req, res);
+
+  assert.strictEqual(pdfParseSpy.mock.callCount(), 1);
+  const arg = (pdfParseSpy.mock.calls as any[])[0].arguments[0];
+  assert.ok(Buffer.isBuffer(arg));
+  assert.deepStrictEqual(arg, Buffer.from('fake pdf'));
 });
 


### PR DESCRIPTION
## Summary
- handle Postmark attachments that supply a file path instead of base64
- cover inbound handler with tests for base64 and file-path inputs

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx tsc api/inbound/postmark.test.ts --module NodeNext --target ES2020 --esModuleInterop --types node,@vercel/node --outDir .tmp-test`
- `node --test .tmp-test/api/inbound/postmark.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68c20e46e73c8331a58322bb1925289f