### PR TITLE
fix pdf-parse import path

### DIFF
--- a/lib/pdf.ts
+++ b/lib/pdf.ts
@@ -1,5 +1,5 @@
 // lib/pdf.ts
-import pdfParse from "pdf-parse";
+import pdfParse from "pdf-parse/lib/pdf-parse.js";
 
 /** dollars string -> cents (integer) */
 function toCents(v: string | number | null | undefined): number | null {


### PR DESCRIPTION
## Summary
- avoid unintended test file reads by importing pdf-parse from explicit lib path

## Testing
- `npx tsc`
- `node --input-type=module <script>`

------
https://chatgpt.com/codex/tasks/task_b_68c2237ef2588331ad1081eaaf55af5b