### PR TITLE
Include raw_json in Postmark receipt upsert

### DIFF
--- a/api/inbound/postmark.test.ts
+++ b/api/inbound/postmark.test.ts
@@ -23,16 +23,17 @@ require.cache[pdfParsePath] = {
 const supabasePath = require.resolve('@supabase/supabase-js');
 const ModuleCtor = require('module');
 const supabaseStub = new ModuleCtor.Module(supabasePath);
+const upsertSpy = mock.fn(() => ({
+  select: () => ({
+    single: async () => ({ data: { id: 1 }, error: null })
+  })
+}));
+
 const fakeSupabase = {
   storage: { from: () => ({ upload: async () => ({ error: null }) }) },
-  from: () => ({
-    upsert: () => ({
-      select: () => ({
-        single: async () => ({ data: { id: 1 }, error: null })
-      })
-    })
-  })
+  from: () => ({ upsert: upsertSpy })
 };
+
 supabaseStub.exports = { createClient: () => fakeSupabase };
 supabaseStub.loaded = true;
 require.cache[supabasePath] = supabaseStub as any;
@@ -42,6 +43,7 @@ const { default: parseHmPdf } = await import('../../lib/pdf.js');
 
 test('passes decoded PDF buffer to parseHmPdf', async () => {
   pdfParseSpy.mock.resetCalls();
+  upsertSpy.mock.resetCalls();
 
   const b64 = Buffer.from('fake pdf').toString('base64');
   const req: any = {
@@ -73,6 +75,7 @@ test('parseHmPdf throws on empty input', async () => {
 
 test('reads attachment from file path when not base64', async () => {
   pdfParseSpy.mock.resetCalls();
+  upsertSpy.mock.resetCalls();
 
   const tmpDir = await fs.mkdtemp(`${os.tmpdir()}/`);
   const filePath = `${tmpDir}/test.pdf`;
@@ -99,5 +102,25 @@ test('reads attachment from file path when not base64', async () => {
   const arg = (pdfParseSpy.mock.calls as any[])[0].arguments[0];
   assert.ok(Buffer.isBuffer(arg));
   assert.deepStrictEqual(arg, Buffer.from('fake pdf'));
+});
+
+test('upsert includes raw_json payload', async () => {
+  upsertSpy.mock.resetCalls();
+
+  const req: any = {
+    method: 'POST',
+    body: {
+      MailboxHash: 'user-123',
+      Subject: 'hello',
+      TextBody: 'world'
+    }
+  };
+  const res: any = { status() { return { json() { return null; } }; } };
+
+  await handler(req, res);
+
+  assert.strictEqual(upsertSpy.mock.callCount(), 1);
+  const arg = (upsertSpy.mock.calls as any[])[0].arguments[0][0];
+  assert.deepStrictEqual(arg.raw_json, req.body);
 });
 

--- a/api/inbound/postmark.ts
+++ b/api/inbound/postmark.ts
@@ -210,7 +210,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           tax_cents,
           shipping_cents,
           currency: "USD",
-          raw_url: storedPath ? `supabase://${RECEIPTS_BUCKET}/${storedPath}` : null
+          raw_url: storedPath ? `supabase://${RECEIPTS_BUCKET}/${storedPath}` : null,
+          raw_json: payload
         }],
         { onConflict: "user_id,merchant,order_id,purchase_date" }
       )


### PR DESCRIPTION
## Summary
- Persist the entire inbound Postmark payload by adding `raw_json` to receipt upsert
- Add unit test verifying the Supabase upsert includes the `raw_json` field

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)*
- `node --test` *(fails: Cannot find module 'pdf-parse')*

------
https://chatgpt.com/codex/tasks/task_b_68c22837e1188331a2927d1ff4275683