### PR TITLE
Fix postmark handler PDF parsing

### DIFF
--- a/api/inbound/postmark.test.ts
+++ b/api/inbound/postmark.test.ts
@@ -37,8 +37,8 @@ const fakeSupabase = {
 supabaseStub.exports = { createClient: () => fakeSupabase };
 supabaseStub.loaded = true;
 require.cache[supabasePath] = supabaseStub as any;
-
-
+const { default: handler } = await import('./postmark.js');
+const { default: parsePdf } = await import('../../lib/pdf.js');
 
 test('passes decoded PDF buffer to parsePdf', async () => {
   pdfParseSpy.mock.resetCalls();
@@ -102,7 +102,3 @@ test('reads attachment from file path when not base64', async () => {
   assert.ok(Buffer.isBuffer(arg));
   assert.deepStrictEqual(arg, Buffer.from('fake pdf'));
 });
-
-
-});
-


### PR DESCRIPTION
## Summary
- resolve merge leftovers in postmark inbound handler
- use `parsePdf` for PDF attachments and add simple HTML parsing fallback
- dynamically import handler in tests for proper stubbing

## Testing
- `npx tsc --noEmit`
- `npx tsc -p tsconfig.json --outDir build`
- `node --test build/api/inbound/postmark.test.js`

------
https://chatgpt.com/codex/tasks/task_b_68c23ab6160c8331abe538545d6b0b3a