### PR TITLE
Improve LLM receipt parsing for unknown merchants

### DIFF
--- a/lib/llm/extract-receipt.ts
+++ b/lib/llm/extract-receipt.ts
@@ -1,24 +1,43 @@
 // lib/llm/extract-receipt.ts
 import type { ParsedReceipt } from "../parse.js";
 
+export interface LlmReceipt extends ParsedReceipt {
+  tax_cents?: number | null;
+  shipping_cents?: number | null;
+}
+
 interface LlmRawResponse {
   merchant?: string;
   order_id?: string;
   purchase_date?: string;
   total_cents?: number | string;
   total?: number | string;
+  tax_cents?: number | string;
+  tax?: number | string;
+  shipping_cents?: number | string;
+  shipping?: number | string;
 }
 
-export default async function extractReceipt(text: string): Promise<ParsedReceipt | null> {
+export default async function extractReceipt(text: string): Promise<LlmReceipt | null> {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) return null;
 
   const messages = [
-    { role: "system", content: "Extract merchant domain, order_id, purchase_date, and total_cents (integer) from the receipt text. Respond with JSON." },
-    { role: "user", content: "Best Buy order confirmation\nOrder #BB123\nTotal: $45.67\nDate: Jan 5, 2024" },
-    { role: "assistant", content: '{"merchant":"bestbuy.com","order_id":"BB123","purchase_date":"Jan 5, 2024","total_cents":4567}' },
-    { role: "user", content: "Target receipt\nOrder: 78910\nPurchase Date: 2024-05-01\nAmount: $15.99" },
-    { role: "assistant", content: '{"merchant":"target.com","order_id":"78910","purchase_date":"2024-05-01","total_cents":1599}' },
+    {
+      role: "system",
+      content:
+        "Extract merchant domain, order_id (also called confirmation or receipt number), purchase_date, total_cents, tax_cents, and shipping_cents as integers from the receipt text. Respond with JSON."
+    },
+    {
+      role: "user",
+      content:
+        "CubeSmart receipt\nConfirmation number: 6179830239\nAmount: $66.77\nDate: Apr 26, 2024"
+    },
+    {
+      role: "assistant",
+      content:
+        '{"merchant":"cubesmart.com","order_id":"6179830239","purchase_date":"Apr 26, 2024","total_cents":6677}'
+    },
     { role: "user", content: text }
   ];
 
@@ -42,19 +61,33 @@ export default async function extractReceipt(text: string): Promise<ParsedReceip
     const cleaned = content.replace(/```json|```/g, "").trim();
     const raw = JSON.parse(cleaned) as LlmRawResponse;
 
-    let total = raw.total_cents ?? raw.total;
-    let total_cents: number | null = null;
-    if (typeof total === "number") total_cents = Math.round(total);
-    else if (typeof total === "string") {
-      const n = parseFloat(total.replace(/[, ]/g, ""));
-      total_cents = isFinite(n) ? Math.round(n * (raw.total_cents != null ? 1 : 100)) : null;
-    }
+    const toCents = (
+      v: number | string | undefined,
+      alreadyCents: boolean
+    ): number | null => {
+      if (typeof v === "number") return Math.round(alreadyCents ? v : v * 100);
+      if (typeof v === "string") {
+        const n = parseFloat(v.replace(/[, ]/g, ""));
+        if (!isFinite(n)) return null;
+        return Math.round(n * (alreadyCents ? 1 : 100));
+      }
+      return null;
+    };
+
+    const total_cents = toCents(raw.total_cents ?? raw.total, raw.total_cents != null);
+    const tax_cents = toCents(raw.tax_cents ?? raw.tax, raw.tax_cents != null);
+    const shipping_cents = toCents(
+      raw.shipping_cents ?? raw.shipping,
+      raw.shipping_cents != null
+    );
 
     return {
       merchant: raw.merchant ? raw.merchant.toLowerCase() : "unknown",
       order_id: raw.order_id || null,
       purchase_date: raw.purchase_date || null,
-      total_cents
+      total_cents,
+      tax_cents,
+      shipping_cents
     };
   } catch (e) {
     console.warn("[llm] extractReceipt failed:", e);


### PR DESCRIPTION
## Summary
- include HTML text in LLM fallback and capture tax/shipping fields
- expand LLM extractReceipt helper to handle confirmation numbers and monetary fields
- surface PDF text to LLM and guess merchant via keywords when parser missing

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test"*)


------
https://chatgpt.com/codex/tasks/task_b_68c23f233d8883319ade26d7bca46b35