### PR TITLE
Improve naive receipt total detection

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -15,7 +15,18 @@ export function naiveParse(text: string, fromEmail: string): ParsedReceipt {
   const dateMatch = text.match(
     /(?:Date|Ordered on|Purchase Date):?\s*([A-Za-z]{3,9}\s+\d{1,2},\s+\d{4}|\d{4}-\d{2}-\d{2})/
   );
-  const totalMatch = text.match(/\$([\d,]+\.\d{2})/);
+  const totalLine = text
+    .split(/\r?\n/)
+    .find((line) => /\btotal\b/i.test(line) && /\$[\d,]+\.\d{2}/.test(line));
+
+  let totalMatch: RegExpMatchArray | undefined;
+
+  if (totalLine) {
+    totalMatch = totalLine.match(/\$([\d,]+\.\d{2})/);
+  } else {
+    const matches = Array.from(text.matchAll(/\$([\d,]+\.\d{2})/g));
+    totalMatch = matches[matches.length - 1];
+  }
 
   const toCents = (s?: string) =>
     s ? Math.round(parseFloat(s.replace(/,/g, "")) * 100) : null;


### PR DESCRIPTION
## Summary
- refine naive receipt parser to prioritize lines containing "Total" and fall back to last dollar amount

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_b_68c59031f5388331b62fffbf141f305e