### PR TITLE
feat: add Amazon OAuth flow

### DIFF
--- a/api/amazon/auth.ts
+++ b/api/amazon/auth.ts
@@ -1,0 +1,16 @@
+// api/amazon/auth.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { getAmazonAuthUrl } from "../../lib/amazon.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const user = (req.query.user as string) || "";
+    if (!user) return res.status(400).json({ ok: false, error: "missing user" });
+
+    const state = Buffer.from(JSON.stringify({ user })).toString("base64url");
+    const url = getAmazonAuthUrl(state);
+    res.redirect(302, url);
+  } catch (e: any) {
+    res.status(400).json({ ok: false, error: String(e?.message || e) });
+  }
+}

--- a/api/amazon/callback.ts
+++ b/api/amazon/callback.ts
@@ -1,0 +1,36 @@
+// api/amazon/callback.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { exchangeCodeForTokens } from "../../lib/amazon.js";
+import { supabaseAdmin } from "../../lib/supabase-admin.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const code = (req.query.code as string) || "";
+    const state = (req.query.state as string) || "";
+    if (!code || !state) return res.status(400).json({ ok: false, error: "missing code or state" });
+
+    let user: string;
+    try {
+      const parsed = JSON.parse(Buffer.from(state, "base64url").toString("utf8"));
+      user = parsed.user;
+    } catch {
+      return res.status(400).json({ ok: false, error: "invalid state" });
+    }
+    if (!user) return res.status(400).json({ ok: false, error: "missing user" });
+
+    const tokens = await exchangeCodeForTokens(code);
+    const expires = new Date(Date.now() + (tokens.expires_in || 3600) * 1000).toISOString();
+    await supabaseAdmin
+      .from("profiles")
+      .update({
+        amazon_access_token: tokens.access_token,
+        amazon_refresh_token: tokens.refresh_token,
+        amazon_access_token_expires_at: expires,
+      })
+      .eq("id", user);
+
+    res.status(200).json({ ok: true });
+  } catch (e: any) {
+    res.status(400).json({ ok: false, error: String(e?.message || e) });
+  }
+}

--- a/lib/amazon.ts
+++ b/lib/amazon.ts
@@ -1,0 +1,88 @@
+// lib/amazon.ts
+import { supabaseAdmin } from "./supabase-admin.js";
+
+const CLIENT_ID = process.env.AMAZON_CLIENT_ID || "";
+const CLIENT_SECRET = process.env.AMAZON_CLIENT_SECRET || "";
+const REDIRECT_URI = process.env.AMAZON_REDIRECT_URI || "";
+
+const AUTH_URL = "https://www.amazon.com/ap/oa";
+const TOKEN_URL = "https://api.amazon.com/auth/o2/token";
+const SCOPES = "profile profile:user_id sellingpartnerapi::orders"; // include order access if available
+
+export function getAmazonAuthUrl(state: string): string {
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    scope: SCOPES,
+    response_type: "code",
+    redirect_uri: REDIRECT_URI,
+    state,
+  });
+  return `${AUTH_URL}?${params.toString()}`;
+}
+
+export async function exchangeCodeForTokens(code: string): Promise<any> {
+  const params = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: REDIRECT_URI,
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+  });
+
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+
+  if (!res.ok) throw new Error(`token exchange failed: ${res.status}`);
+  return res.json();
+}
+
+export async function getValidAccessToken(userId: string): Promise<string | null> {
+  const { data, error } = await supabaseAdmin
+    .from("profiles")
+    .select("amazon_access_token, amazon_refresh_token, amazon_access_token_expires_at")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  const { amazon_access_token, amazon_refresh_token, amazon_access_token_expires_at } = data as any;
+  const expiresAt = amazon_access_token_expires_at ? new Date(amazon_access_token_expires_at) : null;
+  if (
+    amazon_access_token &&
+    expiresAt &&
+    expiresAt.getTime() > Date.now() + 60 * 1000
+  ) {
+    return amazon_access_token;
+  }
+  if (!amazon_refresh_token) return null;
+
+  const params = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: amazon_refresh_token,
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+  });
+
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+  if (!res.ok) throw new Error(`refresh failed: ${res.status}`);
+  const json = await res.json();
+
+  const expires = new Date(Date.now() + (json.expires_in || 3600) * 1000).toISOString();
+  await supabaseAdmin
+    .from("profiles")
+    .update({
+      amazon_access_token: json.access_token,
+      amazon_refresh_token: json.refresh_token || amazon_refresh_token,
+      amazon_access_token_expires_at: expires,
+    })
+    .eq("id", userId);
+
+  return json.access_token as string;
+}
+


### PR DESCRIPTION
## Summary
- add Login with Amazon OAuth endpoints
- store Amazon tokens in user profile and add refresh helper

## Testing
- `npm test` (fails: Missing script)
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c5c95691ac8331bee89290ba82fa69