### PR TITLE
feat: parse amazon order return windows

### DIFF
--- a/api/amazon/orders.ts
+++ b/api/amazon/orders.ts
@@ -1,0 +1,14 @@
+// api/amazon/orders.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { fetchAndStoreAmazonOrders } from "../../lib/amazon-orders.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const user = (req.query.user as string) || "";
+  if (!user) return res.status(400).json({ ok: false, error: "missing user" });
+  try {
+    const orders = await fetchAndStoreAmazonOrders(user);
+    res.status(200).json({ ok: true, orders });
+  } catch (e: any) {
+    res.status(500).json({ ok: false, error: String(e?.message || e) });
+  }
+}

--- a/lib/amazon-orders.ts
+++ b/lib/amazon-orders.ts
@@ -1,0 +1,73 @@
+import { load } from "cheerio";
+import { supabaseAdmin } from "./supabase-admin.js";
+
+export interface AmazonOrder {
+  orderId: string;
+  returnHtml: string;
+  returnEligibleAt: string | null;
+}
+
+async function fetchOrderPage(cookie: string, startIndex = 0): Promise<string> {
+  const url = `https://www.amazon.com/gp/css/order-history?digitalOrders=0&unifiedOrders=1&startIndex=${startIndex}`;
+  const res = await fetch(url, {
+    headers: {
+      cookie,
+      "user-agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    },
+  });
+  if (!res.ok) throw new Error(`order history fetch failed: ${res.status}`);
+  return res.text();
+}
+
+function parseOrders(html: string): AmazonOrder[] {
+  const $ = load(html);
+  const orders: AmazonOrder[] = [];
+  $("div[data-order-id]").each((_, el) => {
+    const orderId = $(el).attr("data-order-id") || "";
+    const retEl = $(el).find(':contains("Eligible through")').first();
+    const returnHtml = retEl.html() || "";
+    const text = retEl.text();
+    let returnEligibleAt: string | null = null;
+    const m = text.match(/Eligible through\s*(.+)/i);
+    if (m) {
+      const parsed = new Date(m[1]);
+      if (!isNaN(parsed.getTime())) returnEligibleAt = parsed.toISOString();
+    }
+    orders.push({ orderId, returnHtml, returnEligibleAt });
+  });
+  return orders;
+}
+
+export async function fetchAndStoreAmazonOrders(userId: string): Promise<AmazonOrder[]> {
+  const { data, error } = await supabaseAdmin
+    .from("profiles")
+    .select("amazon_order_cookies")
+    .eq("id", userId)
+    .maybeSingle();
+  if (error || !data || !data.amazon_order_cookies) throw new Error("missing amazon cookies");
+  const cookie = data.amazon_order_cookies as string;
+
+  let startIndex = 0;
+  const allOrders: AmazonOrder[] = [];
+  while (true) {
+    const html = await fetchOrderPage(cookie, startIndex);
+    const orders = parseOrders(html);
+    if (orders.length === 0) break;
+    allOrders.push(...orders);
+    startIndex += orders.length;
+  }
+
+  if (allOrders.length > 0) {
+    const rows = allOrders.map((o) => ({
+      user_id: userId,
+      order_id: o.orderId,
+      return_html: o.returnHtml,
+      return_eligible_at: o.returnEligibleAt,
+    }));
+    await supabaseAdmin.from("amazon_orders").upsert(rows, {
+      onConflict: "user_id,order_id",
+    });
+  }
+  return allOrders;
+}


### PR DESCRIPTION
## Summary
- fetch Amazon order history pages using stored session cookies
- parse return eligibility dates and persist order metadata
- expose API endpoint to trigger parsing and return structured results

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: process hung)*

------
https://chatgpt.com/codex/tasks/task_b_68c5cbf504a083318b8d5c7670d4b2d4