### PR TITLE
feat: parse and store Amazon order details

### DIFF
--- a/api/amazon/orders.ts
+++ b/api/amazon/orders.ts
@@ -1,0 +1,23 @@
+// api/amazon/orders.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { supabaseAdmin } from "../../lib/supabase-admin.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const user = (req.query.user as string) || "";
+    if (!user) return res.status(400).json({ ok: false, error: "missing user" });
+
+    const { data, error } = await supabaseAdmin
+      .from("amazon_orders")
+      .select(
+        "order_id, order_date, order_url, invoice_url, pdf_url, total_amount, product_name_short"
+      )
+      .eq("user_id", user)
+      .order("order_date", { ascending: false });
+
+    if (error) return res.status(400).json({ ok: false, error: error.message });
+    return res.status(200).json({ ok: true, orders: data || [] });
+  } catch (e: any) {
+    return res.status(500).json({ ok: false, error: String(e?.message || e) });
+  }
+}

--- a/lib/amazon-orders.ts
+++ b/lib/amazon-orders.ts
@@ -1,0 +1,85 @@
+// lib/amazon-orders.ts
+import * as cheerio from "cheerio";
+import { supabaseAdmin } from "./supabase-admin.js";
+
+export interface AmazonOrder {
+  orderId: string;
+  orderDate: string;
+  orderUrl: string;
+  invoiceUrl: string;
+  pdfUrl?: string;
+  totalAmount: string;
+  productNameShort: string;
+}
+
+export function parseOrders(html: string): AmazonOrder[] {
+  const $ = cheerio.load(html);
+  const orders: AmazonOrder[] = [];
+
+  // Attempt to locate order containers; fall back to generic selectors
+  $(".order, .order-card").each((_, el) => {
+    const element = $(el);
+    const orderId =
+      element.find("[data-test-id='order-id'], .order-id, .a-link-normal[href*='orderID']").first().text().trim() ||
+      element.attr("data-order-id") ||
+      "";
+    const orderDate =
+      element.find(".order-date, [data-test-id='order-date']").first().text().trim();
+    const orderUrl =
+      element.find(".order-id a, a[href*='order-details']").attr("href") || "";
+    const invoiceUrl = element.find("a:contains('Invoice')").attr("href") || "";
+
+    const totalAmount =
+      element
+        .find(".order-total, .grand-total-price, [data-test-id='order-total']")
+        .first()
+        .text()
+        .trim();
+
+    const productTitle =
+      element
+        .find(".product-title, .a-link-normal[href*='product'], [data-test-id='item-title']")
+        .first()
+        .text()
+        .trim();
+    const productNameShort = productTitle.split(/\s+/).slice(0, 3).join(" ");
+
+    orders.push({
+      orderId,
+      orderDate,
+      orderUrl,
+      invoiceUrl,
+      totalAmount,
+      productNameShort,
+    });
+  });
+
+  return orders;
+}
+
+export async function fetchAndStoreAmazonOrders(
+  userId: string,
+  html: string
+): Promise<AmazonOrder[]> {
+  const orders = parseOrders(html);
+  if (!orders.length) return [];
+
+  const payload = orders.map((o) => ({
+    user_id: userId,
+    order_id: o.orderId,
+    order_date: o.orderDate,
+    order_url: o.orderUrl,
+    invoice_url: o.invoiceUrl,
+    pdf_url: o.pdfUrl ?? null,
+    total_amount: o.totalAmount,
+    product_name_short: o.productNameShort,
+  }));
+
+  const { error } = await supabaseAdmin
+    .from("amazon_orders")
+    .upsert(payload, { onConflict: "order_id" });
+
+  if (error) throw error;
+  return orders;
+}
+


### PR DESCRIPTION
## Summary
- add Cheerio-based Amazon order parsing
- store and expose order totals and short product names

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c5d0a7872483319951eeacc46cf95b