### PR TITLE
feat: add Gmail OAuth linking

### DIFF
--- a/api/gmail/auth.ts
+++ b/api/gmail/auth.ts
@@ -1,0 +1,16 @@
+// api/gmail/auth.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { getGmailAuthUrl } from "../../lib/gmail.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const user = (req.query.user as string) || "";
+    if (!user) return res.status(400).json({ ok: false, error: "missing user" });
+
+    const state = Buffer.from(JSON.stringify({ user })).toString("base64url");
+    const url = getGmailAuthUrl(state);
+    res.redirect(302, url);
+  } catch (e: any) {
+    res.status(400).json({ ok: false, error: String(e?.message || e) });
+  }
+}

--- a/api/gmail/callback.ts
+++ b/api/gmail/callback.ts
@@ -1,0 +1,36 @@
+// api/gmail/callback.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { exchangeCodeForTokens } from "../../lib/gmail.js";
+import { supabaseAdmin } from "../../lib/supabase-admin.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const code = (req.query.code as string) || "";
+    const state = (req.query.state as string) || "";
+    if (!code || !state) return res.status(400).json({ ok: false, error: "missing code or state" });
+
+    let user: string;
+    try {
+      const parsed = JSON.parse(Buffer.from(state, "base64url").toString("utf8"));
+      user = parsed.user;
+    } catch {
+      return res.status(400).json({ ok: false, error: "invalid state" });
+    }
+    if (!user) return res.status(400).json({ ok: false, error: "missing user" });
+
+    const tokens = await exchangeCodeForTokens(code);
+    const expires = tokens.expiry_date ? new Date(tokens.expiry_date).toISOString() : null;
+    await supabaseAdmin
+      .from("gmail_tokens")
+      .upsert({
+        user_id: user,
+        refresh_token: tokens.refresh_token,
+        access_token: tokens.access_token,
+        access_token_expires_at: expires,
+      }, { onConflict: "user_id" });
+
+    res.status(200).json({ ok: true });
+  } catch (e: any) {
+    res.status(400).json({ ok: false, error: String(e?.message || e) });
+  }
+}

--- a/api/gmail/ui.ts
+++ b/api/gmail/ui.ts
@@ -1,0 +1,18 @@
+// api/gmail/ui.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const user = (req.query.user as string) || "";
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  if (!user) {
+    res.status(400).send("Missing user param");
+    return;
+  }
+  res.status(200).send(`<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8" /><title>Link Gmail</title></head>
+<body>
+  <button onclick="location.href='/api/gmail/auth?user=${encodeURIComponent(user)}'">Link Gmail</button>
+</body>
+</html>`);
+}

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -1,0 +1,28 @@
+// lib/gmail.ts
+import { google } from "googleapis";
+
+const CLIENT_ID = process.env.GMAIL_CLIENT_ID || "";
+const CLIENT_SECRET = process.env.GMAIL_CLIENT_SECRET || "";
+const REDIRECT_URI = process.env.GMAIL_REDIRECT_URI || "";
+
+const SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"];
+
+function oauthClient() {
+  return new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+}
+
+export function getGmailAuthUrl(state: string): string {
+  const client = oauthClient();
+  return client.generateAuthUrl({
+    access_type: "offline",
+    scope: SCOPES,
+    state,
+    prompt: "consent",
+  });
+}
+
+export async function exchangeCodeForTokens(code: string) {
+  const client = oauthClient();
+  const { tokens } = await client.getToken(code);
+  return tokens;
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.43.0",
     "pdf-parse": "^1.1.1",
-    "cheerio": "^1.0.0-rc.12"
+    "cheerio": "^1.0.0-rc.12",
+    "googleapis": "^131.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",


### PR DESCRIPTION
## Summary
- redirect to Google OAuth for Gmail read-only linking
- handle Gmail OAuth callback and store tokens in Supabase
- minimal HTML button to trigger Gmail linking

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'googleapis')*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c5e590d8588331ab368553a88122ee