### PR TITLE
Add Gmail merchant scanning endpoint

### DIFF
--- a/api/gmail/merchants.ts
+++ b/api/gmail/merchants.ts
@@ -1,0 +1,15 @@
+// api/gmail/merchants.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { scanGmailMerchants } from "../../lib/gmail-scan.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const user = (req.query.user as string) || "";
+    if (!user) return res.status(400).json({ ok: false, error: "missing user" });
+
+    const merchants = await scanGmailMerchants(user);
+    res.status(200).json({ ok: true, merchants });
+  } catch (e: any) {
+    res.status(400).json({ ok: false, error: String(e?.message || e) });
+  }
+}

--- a/lib/gmail-scan.ts
+++ b/lib/gmail-scan.ts
@@ -1,0 +1,71 @@
+// lib/gmail-scan.ts
+import { google } from "googleapis";
+import { supabaseAdmin } from "./supabase-admin.js";
+
+const CLIENT_ID = process.env.GMAIL_CLIENT_ID || "";
+const CLIENT_SECRET = process.env.GMAIL_CLIENT_SECRET || "";
+const REDIRECT_URI = process.env.GMAIL_REDIRECT_URI || "";
+
+/**
+ * Fetch a valid Gmail access token for the user.
+ */
+async function getAccessToken(userId: string): Promise<{ client: any; accessToken: string } | null> {
+  const { data, error } = await supabaseAdmin
+    .from("gmail_tokens")
+    .select("refresh_token, access_token, access_token_expires_at")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error || !data || !data.refresh_token) return null;
+
+  const client = new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+  const refreshToken = data.refresh_token as string;
+  const accessToken = data.access_token as string | null;
+  const expiry = data.access_token_expires_at ? new Date(data.access_token_expires_at).getTime() : undefined;
+
+  client.setCredentials({ refresh_token: refreshToken, access_token: accessToken || undefined, expiry_date: expiry });
+  const { token } = await client.getAccessToken();
+  if (!token) return null;
+
+  // persist new access token if it changed
+  if (token !== accessToken) {
+    const expiryDate = client.credentials.expiry_date
+      ? new Date(client.credentials.expiry_date).toISOString()
+      : null;
+    await supabaseAdmin
+      .from("gmail_tokens")
+      .update({ access_token: token, access_token_expires_at: expiryDate })
+      .eq("user_id", userId);
+  }
+
+  return { client, accessToken: token };
+}
+
+function extractDomain(from: string): string | null {
+  const match = from.match(/@([^>\s]+)/);
+  return match ? match[1].toLowerCase() : null;
+}
+
+export async function scanGmailMerchants(userId: string): Promise<string[]> {
+  const tokens = await getAccessToken(userId);
+  if (!tokens) return [];
+  const { client } = tokens;
+  const gmail = google.gmail({ version: "v1", auth: client });
+
+  const list = await gmail.users.messages.list({ userId: "me", maxResults: 50, labelIds: ["INBOX"] });
+  const messages = list.data.messages || [];
+  const merchants = new Set<string>();
+
+  for (const msg of messages) {
+    if (!msg.id) continue;
+    const res = await gmail.users.messages.get({ userId: "me", id: msg.id, format: "metadata", metadataHeaders: ["From"] });
+    const headers = res.data.payload?.headers || [];
+    const from = headers.find((h: any) => (h.name || "").toLowerCase() === "from")?.value;
+    if (!from) continue;
+    const domain = extractDomain(from);
+    if (domain) merchants.add(domain);
+  }
+
+  return Array.from(merchants);
+}
+


### PR DESCRIPTION
## Summary
- add gmail scanner module to derive merchant domains from recent messages
- expose `/api/gmail/merchants` endpoint to return merchants for a user

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'googleapis')*


------
https://chatgpt.com/codex/tasks/task_b_68c603aa98448331aca0ae58e0b85f7c