### PR TITLE
feat: authorize Gmail merchants

### DIFF
--- a/api/gmail/merchants-ui.ts
+++ b/api/gmail/merchants-ui.ts
@@ -1,0 +1,49 @@
+// api/gmail/merchants-ui.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const user = (req.query.user as string) || "";
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  if (!user) {
+    res.status(400).send("Missing user param");
+    return;
+  }
+
+  res.status(200).send(`<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8" /><title>Authorize Merchants</title></head>
+<body>
+  <div id="list"></div>
+  <button id="save">Save</button>
+  <script>
+    const user = ${JSON.stringify(user)};
+    async function load(){
+      const r = await fetch('/api/gmail/merchants?user=' + encodeURIComponent(user));
+      const data = await r.json();
+      const list = document.getElementById('list');
+      (data.merchants || []).forEach(m => {
+        const label = document.createElement('label');
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.value = m;
+        label.appendChild(cb);
+        label.appendChild(document.createTextNode(' ' + m));
+        const div = document.createElement('div');
+        div.appendChild(label);
+        list.appendChild(div);
+      });
+    }
+    document.getElementById('save').onclick = async () => {
+      const selected = Array.from(document.querySelectorAll('#list input[type="checkbox"]:checked')).map(cb => cb.value);
+      await fetch('/api/gmail/merchants', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user, merchants: selected })
+      });
+      alert('Saved');
+    };
+    load();
+  </script>
+</body>
+</html>`);
+}

--- a/api/gmail/merchants.ts
+++ b/api/gmail/merchants.ts
@@ -1,14 +1,31 @@
 // api/gmail/merchants.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { scanGmailMerchants } from "../../lib/gmail-scan.js";
+import { upsertAuthorizedMerchants } from "../../lib/merchants.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
-    const user = (req.query.user as string) || "";
-    if (!user) return res.status(400).json({ ok: false, error: "missing user" });
+    if (req.method === "GET") {
+      const user = (req.query.user as string) || "";
+      if (!user) return res.status(400).json({ ok: false, error: "missing user" });
 
-    const merchants = await scanGmailMerchants(user);
-    res.status(200).json({ ok: true, merchants });
+      const merchants = await scanGmailMerchants(user);
+      return res.status(200).json({ ok: true, merchants });
+    }
+
+    if (req.method === "POST") {
+      const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+      const { user, merchants } = body || {};
+      if (!user || !Array.isArray(merchants)) {
+        return res.status(400).json({ ok: false, error: "missing user or merchants" });
+      }
+
+      await upsertAuthorizedMerchants(user, merchants);
+      return res.status(200).json({ ok: true });
+    }
+
+    res.setHeader("Allow", "GET,POST");
+    res.status(405).end();
   } catch (e: any) {
     res.status(400).json({ ok: false, error: String(e?.message || e) });
   }

--- a/covrily-context-docs/Supabase_db.sql
+++ b/covrily-context-docs/Supabase_db.sql
@@ -144,3 +144,9 @@ CREATE TABLE public.receipts (
   CONSTRAINT receipts_pkey PRIMARY KEY (id),
   CONSTRAINT receipts_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id)
 );
+
+CREATE TABLE public.auth_merchants (
+  user_id uuid NOT NULL,
+  merchant text NOT NULL,
+  CONSTRAINT auth_merchants_pkey PRIMARY KEY (user_id, merchant)
+);

--- a/lib/merchants.ts
+++ b/lib/merchants.ts
@@ -1,0 +1,17 @@
+// lib/merchants.ts
+import { supabaseAdmin } from "./supabase-admin.js";
+
+export async function upsertAuthorizedMerchants(userId: string, merchants: string[]): Promise<void> {
+  if (!userId || !Array.isArray(merchants)) return;
+
+  // Replace existing authorized merchants with the provided list
+  await supabaseAdmin.from("auth_merchants").delete().eq("user_id", userId);
+  if (merchants.length === 0) return;
+
+  const payload = merchants.map((m) => ({ user_id: userId, merchant: m }));
+  const { error } = await supabaseAdmin
+    .from("auth_merchants")
+    .upsert(payload, { onConflict: "user_id,merchant" });
+
+  if (error) throw error;
+}


### PR DESCRIPTION
## Summary
- add auth_merchants table definition
- allow upserting authorized merchants and POST support for /api/gmail/merchants
- add simple UI for selecting merchants from Gmail scan

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'googleapis')*


------
https://chatgpt.com/codex/tasks/task_b_68c6069cc15c8331b0f1b28a37907ca4