### PR TITLE
feat: add merchants endpoint for user

### DIFF
--- a/api/me/merchants.ts
+++ b/api/me/merchants.ts
@@ -1,0 +1,21 @@
+import { createClient } from "@supabase/supabase-js";
+
+export default async function handler(req: any, res: any) {
+  const user = (req.query.user as string) || "";
+  if (!user) return res.status(400).json({ ok:false, error:"missing user" });
+
+  const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data: rows, error } = await supabase
+    .from("auth_merchants")
+    .select("merchant")
+    .eq("user_id", user)
+    .order("merchant", { ascending: true });
+
+  if (error) return res.status(500).json({ ok:false, error });
+
+  const merchants = (rows || []).map((r: any) => r.merchant);
+  return res.status(200).json({ ok:true, merchants });
+}


### PR DESCRIPTION
## Summary
- add `/api/me/merchants` endpoint to fetch a user's authorized merchants
- existing `/api/me/receipts` endpoint already reads from `receipts` table used by Gmail ingest, so new receipts appear automatically

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c60d7263d083319ddfcf4b8d17e6ca