### PR TITLE
feat: add Gmail auth section to admin UI

### DIFF
--- a/api/admin/gmail-token.ts
+++ b/api/admin/gmail-token.ts
@@ -1,0 +1,27 @@
+// api/admin/gmail-token.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN || "";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const token = (req.headers["x-admin-token"] as string) || (req.query.token as string) || "";
+  if (!ADMIN_TOKEN || token !== ADMIN_TOKEN) {
+    return res.status(401).json({ ok: false, error: "unauthorized" });
+  }
+
+  const user = (req.query.user as string) || "";
+  if (!user) return res.status(400).json({ ok: false, error: "missing user" });
+
+  const sb = createClient(SUPABASE_URL, SERVICE_KEY, { auth: { persistSession: false } });
+  const { data, error } = await sb
+    .from("gmail_tokens")
+    .select("user_id")
+    .eq("user_id", user)
+    .maybeSingle();
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+
+  return res.status(200).json({ ok: true, exists: !!data });
+}


### PR DESCRIPTION
## Summary
- add Gmail Auth section to admin UI with user lookup and status
- allow checking existing Gmail token via new admin endpoint

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c61098d0a4833194999d629361d835