### PR TITLE
Redirect Gmail OAuth callbacks and show status UI

### DIFF
--- a/api/gmail/callback.ts
+++ b/api/gmail/callback.ts
@@ -4,33 +4,37 @@ import { exchangeCodeForTokens } from "../../lib/gmail.js";
 import { supabaseAdmin } from "../../lib/supabase-admin.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  let user = "";
   try {
     const code = (req.query.code as string) || "";
     const state = (req.query.state as string) || "";
-    if (!code || !state) return res.status(400).json({ ok: false, error: "missing code or state" });
+    if (!code || !state) throw new Error("missing code or state");
 
-    let user: string;
     try {
       const parsed = JSON.parse(Buffer.from(state, "base64url").toString("utf8"));
       user = parsed.user;
     } catch {
-      return res.status(400).json({ ok: false, error: "invalid state" });
+      throw new Error("invalid state");
     }
-    if (!user) return res.status(400).json({ ok: false, error: "missing user" });
+    if (!user) throw new Error("missing user");
 
     const tokens = await exchangeCodeForTokens(code);
     const expires = tokens.expiry_date ? new Date(tokens.expiry_date).toISOString() : null;
     await supabaseAdmin
       .from("gmail_tokens")
-      .upsert({
-        user_id: user,
-        refresh_token: tokens.refresh_token,
-        access_token: tokens.access_token,
-        access_token_expires_at: expires,
-      }, { onConflict: "user_id" });
+      .upsert(
+        {
+          user_id: user,
+          refresh_token: tokens.refresh_token,
+          access_token: tokens.access_token,
+          access_token_expires_at: expires,
+        },
+        { onConflict: "user_id" }
+      );
 
-    res.status(200).json({ ok: true });
+    res.redirect(302, `/api/gmail/ui?user=${encodeURIComponent(user)}&status=linked`);
   } catch (e: any) {
-    res.status(400).json({ ok: false, error: String(e?.message || e) });
+    const qs = user ? `user=${encodeURIComponent(user)}&` : "";
+    res.redirect(302, `/api/gmail/ui?${qs}status=error`);
   }
 }

--- a/api/gmail/ui.ts
+++ b/api/gmail/ui.ts
@@ -3,16 +3,28 @@ import type { VercelRequest, VercelResponse } from "@vercel/node";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const user = (req.query.user as string) || "";
+  const status = (req.query.status as string) || "";
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   if (!user) {
     res.status(400).send("Missing user param");
     return;
   }
+
+  let bodyContent = "";
+  if (status === "linked") {
+    bodyContent = "<p>Gmail account linked successfully.</p>";
+  } else if (status === "error") {
+    bodyContent = "<p>Failed to link Gmail. Please try again.</p>";
+  } else {
+    bodyContent = `<button onclick="location.href='/api/gmail/auth?user=${encodeURIComponent(user)}'">Link Gmail</button>`;
+  }
+
   res.status(200).send(`<!doctype html>
 <html lang="en">
 <head><meta charset="utf-8" /><title>Link Gmail</title></head>
 <body>
-  <button onclick="location.href='/api/gmail/auth?user=${encodeURIComponent(user)}'">Link Gmail</button>
+  ${bodyContent}
 </body>
 </html>`);
 }
+


### PR DESCRIPTION
## Summary
- Redirect Gmail OAuth callback to UI with success or error status
- Show Gmail linking status messages instead of only a button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c611ab31e08331aa7d8ca945d69d26