### PR TITLE
chore: skip amazon in gmail scan

### DIFF
--- a/lib/gmail-scan.ts
+++ b/lib/gmail-scan.ts
@@ -65,7 +65,8 @@ export async function scanGmailMerchants(userId: string): Promise<string[]> {
     const from = headers.find((h: any) => (h.name || "").toLowerCase() === "from")?.value;
     if (!from) continue;
     const domain = extractDomain(from);
-    if (domain) merchants.add(domain);
+    if (!domain || domain.includes('amazon.')) continue;
+    merchants.add(domain);
   }
 
   return Array.from(merchants);


### PR DESCRIPTION
## Summary
- filter out Amazon domains when scanning Gmail merchants

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c62b9104908331b20f60c4f7f31e91