### PR TITLE
Paginate Gmail scan and normalize merchant domains

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "@supabase/supabase-js": "^2.43.0",
     "pdf-parse": "^1.1.1",
     "cheerio": "^1.0.0-rc.12",
-    "googleapis": "^131.0.0"
+    "googleapis": "^131.0.0",
+    "tldts": "^6.1.24"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",


### PR DESCRIPTION
## Summary
- paginate Gmail inbox scanning with page tokens and configurable limit
- use tldts to extract registrable root domain from message senders
- dedupe merchants before persisting to auth_merchants

## Testing
- `npm install tldts --no-package-lock --registry=https://registry.npmjs.org` *(fails: 403 Forbidden)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'tldts')*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c62c53bcf08331a836b49971f4a3e8