### PR TITLE
Improve styling for Gmail auth and merchant selection UI

### DIFF
--- a/api/gmail/merchants-ui.ts
+++ b/api/gmail/merchants-ui.ts
@@ -11,26 +11,44 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   res.status(200).send(`<!doctype html>
 <html lang="en">
-<head><meta charset="utf-8" /><title>Authorize Merchants</title></head>
+<head>
+  <meta charset="utf-8" />
+  <title>Authorize Merchants</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px auto; max-width: 600px; line-height: 1.6; }
+    h1 { text-align: center; }
+    #list { margin: 1rem 0; }
+    .merchant { display: flex; align-items: center; margin: 0.25rem 0; }
+    .merchant input { margin-right: 0.5rem; }
+    #save { padding: 0.5rem 1rem; font-size: 1rem; cursor: pointer; }
+  </style>
+</head>
 <body>
-  <div id="list"></div>
-  <button id="save">Save</button>
+  <main>
+    <h1>Select merchants</h1>
+    <p>Choose the merchants whose receipts you'd like to import.</p>
+    <div id="list"></div>
+    <button id="save">Save</button>
+  </main>
   <script>
     const user = ${JSON.stringify(user)};
     async function load(){
       const r = await fetch('/api/gmail/merchants?user=' + encodeURIComponent(user));
       const data = await r.json();
       const list = document.getElementById('list');
+      if (!data.merchants || data.merchants.length === 0) {
+        list.innerHTML = '<p>No merchants found.</p>';
+        return;
+      }
       (data.merchants || []).forEach(m => {
         const label = document.createElement('label');
+        label.className = 'merchant';
         const cb = document.createElement('input');
         cb.type = 'checkbox';
         cb.value = m;
         label.appendChild(cb);
-        label.appendChild(document.createTextNode(' ' + m));
-        const div = document.createElement('div');
-        div.appendChild(label);
-        list.appendChild(div);
+        label.appendChild(document.createTextNode(m));
+        list.appendChild(label);
       });
     }
     document.getElementById('save').onclick = async () => {

--- a/api/gmail/ui.ts
+++ b/api/gmail/ui.ts
@@ -12,16 +12,32 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   let bodyContent = "";
   if (status === "error") {
-    bodyContent = "<p>Failed to link Gmail. Please try again.</p>";
+    bodyContent = "<p class='error'>Failed to link Gmail. Please try again.</p>";
   } else {
-    bodyContent = `<button onclick="location.href='/api/gmail/auth?user=${encodeURIComponent(user)}'">Link Gmail</button>`;
+    bodyContent = "<p>We need permission to scan your inbox for receipts.</p><button id='link'>Link Gmail</button>";
   }
 
   res.status(200).send(`<!doctype html>
 <html lang="en">
-<head><meta charset="utf-8" /><title>Link Gmail</title></head>
+<head>
+  <meta charset="utf-8" />
+  <title>Link Gmail</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px auto; max-width: 600px; line-height: 1.6; text-align: center; }
+    button { padding: 0.6rem 1.2rem; font-size: 1rem; cursor: pointer; }
+    .error { color: #b00020; }
+  </style>
+</head>
 <body>
-  ${bodyContent}
+  <main>
+    <h1>Connect your Gmail</h1>
+    ${bodyContent}
+  </main>
+  <script>
+    const user = ${JSON.stringify(user)};
+    const btn = document.getElementById('link');
+    if (btn) btn.onclick = () => { location.href = '/api/gmail/auth?user=' + encodeURIComponent(user); };
+  </script>
 </body>
 </html>`);
 }


### PR DESCRIPTION
## Summary
- Add simple styling and layout to Gmail linking page
- Style merchant selection UI and show helpful messages

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json` (fails: Cannot find module 'tldts')

------
https://chatgpt.com/codex/tasks/task_b_68c6ca8b3c208331a770a72a0d5f7f27