### PR TITLE
Enhance Gmail scan filters

### DIFF
--- a/lib/gmail-scan.ts
+++ b/lib/gmail-scan.ts
@@ -61,8 +61,8 @@ export async function scanGmailMerchants(userId: string): Promise<string[]> {
   const dateStr = `${since.getFullYear()}/${String(since.getMonth() + 1).padStart(2, "0")}/${String(
     since.getDate()
   ).padStart(2, "0")}`;
-  const q = `(receipt OR order OR invoice OR purchase OR bill OR transaction) after:${dateStr}`;
-  const keywordRegex = /\b(receipt|order|invoice|purchase|bill|transaction)\b/i;
+  const q = `subject:(receipt OR order OR invoice OR purchase OR bill OR transaction OR payment OR confirmation OR statement OR "your order" OR "receipt for") (category:updates OR label:purchases) after:${dateStr}`;
+  const keywordRegex = /\b(receipt(?:\s+for)?|your\s+order|invoice|purchase|bill|transaction|payment|confirmation|statement|order)\b/i;
 
   const merchants = new Set<string>();
   let pageToken: string | undefined;


### PR DESCRIPTION
## Summary
- broaden Gmail search query to look for additional purchase-related subject keywords and restrict to purchase-related categories
- expand keyword regex to cover new terms like payment and confirmation

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c6e9d217988331aaf9fa2a121d4987