### PR TITLE
Trigger Gmail receipt ingestion after merchant approval

### DIFF
--- a/api/gmail/merchants.ts
+++ b/api/gmail/merchants.ts
@@ -3,6 +3,7 @@ import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { scanGmailMerchants } from "../../lib/gmail-scan.js";
 import { saveApprovedMerchants } from "../../lib/merchants.js";
 import { supabaseAdmin } from "../../lib/supabase-admin.js";
+import { ingestUserReceipts } from "./ingest.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
@@ -33,6 +34,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
 
       await saveApprovedMerchants(user, merchants);
+      await ingestUserReceipts(user);
       return res.status(200).json({ ok: true });
     }
 


### PR DESCRIPTION
## Summary
- Expose `ingestUserReceipts` to scan unread Gmail receipts for a user's approved merchants
- Automatically invoke receipt ingestion after merchants are approved

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c7071f47c88331aa5018a3f5baa6f2