### PR TITLE
Track pending receipt links requiring login

### DIFF
--- a/covrily-context-docs/Supabase_db.sql
+++ b/covrily-context-docs/Supabase_db.sql
@@ -156,3 +156,17 @@ CREATE TABLE public.approved_merchants (
   merchant text NOT NULL,
   CONSTRAINT approved_merchants_pkey PRIMARY KEY (user_id, merchant)
 );
+
+CREATE TABLE public.pending_receipts (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  user_id uuid,
+  message_id text,
+  url text NOT NULL,
+  merchant text,
+  subject text,
+  from_header text,
+  status_code integer,
+  created_at timestamp with time zone DEFAULT now(),
+  CONSTRAINT pending_receipts_pkey PRIMARY KEY (id),
+  CONSTRAINT pending_receipts_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id)
+);

--- a/covrily-context-docs/special-handling-domains.md
+++ b/covrily-context-docs/special-handling-domains.md
@@ -1,0 +1,11 @@
+# Domains Requiring Special Handling
+
+When receipt links return a login page (HTTP 401, 403 or a redirect to a login page),
+the URL and message metadata are stored in the `pending_receipts` table for later
+processing with a headless browser. These domains may need merchant-specific
+scripts to automate authentication or scraping.
+
+Add any domains observed in `pending_receipts` below so the team can prioritize
+custom handlers:
+
+- _none yet_


### PR DESCRIPTION
## Summary
- log and persist receipt links that require authentication
- outline pending_receipts table and list domains needing special handling

## Testing
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c7672d443483319a1403a7f7d84def