### PR TITLE
Enhance Gmail receipt ingestion heuristics

### DIFF
--- a/api/gmail/ingest.ts
+++ b/api/gmail/ingest.ts
@@ -1,5 +1,5 @@
 // api/gmail/ingest.ts
-// Fetch unread Gmail messages for approved merchants and store receipts
+// Fetch Gmail messages for approved merchants and store receipts
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { google } from "googleapis";
@@ -10,10 +10,91 @@ import { getAccessToken } from "../../lib/gmail-scan.js";
 import { withRetry } from "../../lib/retry.js";
 import extractReceipt from "../../lib/llm/extract-receipt.js";
 import { logParseResult } from "../../lib/parse-log.js";
-import extractReceiptLink from "../../lib/llm/extract-receipt-link.js";
+import extractReceiptLink, {
+  type ReceiptLinkCandidate,
+} from "../../lib/llm/extract-receipt-link.js";
 import { load } from "cheerio";
 
 export const config = { runtime: "nodejs" };
+
+const PROCESSED_LABEL_NAME = "CovrilyProcessed";
+
+interface AnchorCandidate {
+  href: string;
+  text: string;
+  score: number;
+}
+
+function hasReceiptIndicators(text: string): boolean {
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  const keywordRegex = /(receipt|invoice|order|purchase|confirmation|payment)/i;
+  const viewRegex = /view (?:your )?(?:order|receipt|invoice|purchase|details)/i;
+  const idRegex =
+    /(order|receipt|invoice|confirmation|transaction)[^\n]{0,20}(number|no\.?|#|id)?\s*[:#]?\s*[a-z0-9][a-z0-9-]{3,}/i;
+  const amountRegex = /\$\s?\d{1,3}(?:,\d{3})*(?:\.\d{2})?/;
+
+  const hasKeyword = keywordRegex.test(text);
+  const hasView = viewRegex.test(lower);
+  const hasId = idRegex.test(text);
+  const hasAmount = amountRegex.test(text);
+
+  let score = 0;
+  if (hasKeyword) score += 1;
+  if (hasView) score += 1;
+  if (hasId) score += 2;
+  if (hasAmount) score += 2;
+
+  return score >= 3 && hasAmount;
+}
+
+async function ensureProcessedLabel(gmail: any): Promise<string | null> {
+  const lookup = async () => {
+    const labelsResp: any = await withRetry(
+      () => gmail.users.labels.list({ userId: "me" }),
+      "users.labels.list"
+    );
+    const all = labelsResp?.data?.labels || [];
+    const lowerName = PROCESSED_LABEL_NAME.toLowerCase();
+    const match = all.find(
+      (label: any) => (label.name || "").toLowerCase() === lowerName
+    );
+    return match?.id || null;
+  };
+
+  try {
+    const existing = await lookup();
+    if (existing) return existing;
+  } catch (err) {
+    console.warn("[gmail] labels.list failed", err);
+  }
+
+  try {
+    const createdResp: any = await withRetry(
+      () =>
+        gmail.users.labels.create({
+          userId: "me",
+          requestBody: {
+            name: PROCESSED_LABEL_NAME,
+            labelListVisibility: "labelHide",
+            messageListVisibility: "hide",
+          },
+        }),
+      "users.labels.create"
+    );
+    const id = createdResp?.data?.id;
+    if (id) return id;
+  } catch (err) {
+    console.warn("[gmail] labels.create failed", err);
+  }
+
+  try {
+    return await lookup();
+  } catch (err) {
+    console.warn("[gmail] labels.list retry failed", err);
+    return null;
+  }
+}
 
 function b64ToBuf(b64: string): Buffer {
   const norm = b64.replace(/-/g, "+").replace(/_/g, "/");
@@ -48,17 +129,25 @@ function findHtmlPart(part: any): any | null {
   return null;
 }
 
-function gatherAnchors(html: string): string[] {
+function gatherAnchors(html: string): AnchorCandidate[] {
   const $ = load(html);
-  const links: string[] = [];
+  const links: AnchorCandidate[] = [];
   $("a[href]").each((_, el) => {
     const href = $(el).attr("href");
-    if (href) links.push(href);
+    if (!href) return;
+    const text = $(el)
+      .text()
+      .replace(/\s+/g, " ")
+      .trim();
+    links.push({ href, text, score: 0 });
   });
   return links;
 }
 
-async function findReceiptLink(payload: any, from: string): Promise<string | null> {
+async function findReceiptLink(
+  payload: any,
+  from: string
+): Promise<string | null> {
   const htmlPart = findHtmlPart(payload);
   const data = htmlPart?.body?.data;
   if (!data) return null;
@@ -66,19 +155,64 @@ async function findReceiptLink(payload: any, from: string): Promise<string | nul
   const links = gatherAnchors(html);
   if (links.length === 0) return null;
   const senderDomain = (from.match(/@([^>\s]+)/)?.[1] || "").toLowerCase();
-  const filtered = links.filter((url) => {
-    try {
-      const u = new URL(url);
-      const domainMatch = senderDomain && u.hostname.toLowerCase().endsWith(senderDomain);
-      const keywordMatch = /(order|receipt|invoice|view)/i.test(url);
-      return domainMatch || keywordMatch;
-    } catch {
-      return false;
-    }
-  });
-  if (filtered.length === 0) return null;
-  if (filtered.length === 1) return filtered[0];
-  return await extractReceiptLink(filtered);
+  const keywordRegex = /(order|receipt|invoice|purchase|view|details)/i;
+  const viewRegex = /view (?:your )?(?:order|receipt|invoice|details)/i;
+  const idRegex =
+    /(order|receipt|invoice|confirmation)[^\n]{0,20}[:#]?\s*[a-z0-9][a-z0-9-]{3,}/i;
+
+  const scored = links
+    .map((link) => {
+      let domainMatch = false;
+      let urlKeyword = false;
+      let validUrl = false;
+      try {
+        const u = new URL(link.href);
+        validUrl = u.protocol === "http:" || u.protocol === "https:";
+        domainMatch =
+          !!senderDomain && u.hostname.toLowerCase().endsWith(senderDomain);
+        urlKeyword = keywordRegex.test(link.href);
+      } catch {
+        domainMatch = false;
+      }
+      const textKeyword = keywordRegex.test(link.text);
+      const viewMatch = viewRegex.test(link.text.toLowerCase());
+      const idMatch = idRegex.test(link.text);
+      const score =
+        (domainMatch ? 3 : 0) +
+        (urlKeyword ? 2 : 0) +
+        (textKeyword ? 3 : 0) +
+        (viewMatch ? 3 : 0) +
+        (idMatch ? 1 : 0);
+      return {
+        ...link,
+        score,
+        domainMatch,
+        textKeyword,
+        urlKeyword,
+        viewMatch,
+        validUrl,
+      };
+    })
+    .filter(
+      (link) =>
+        link.validUrl &&
+        (link.domainMatch || link.urlKeyword || link.textKeyword || link.viewMatch)
+    );
+
+  if (scored.length === 0) return null;
+
+  scored.sort((a, b) => b.score - a.score);
+
+  if (scored.length === 1) return scored[0].href;
+
+  const candidates: ReceiptLinkCandidate[] = scored.map((link) => ({
+    url: link.href,
+    anchorText: link.text,
+  }));
+
+  const llmChoice = await extractReceiptLink(candidates);
+  if (llmChoice) return llmChoice;
+  return scored[0].href;
 }
 
 export async function fetchReceiptFromLink(
@@ -202,10 +336,39 @@ async function isReceiptLLM(text: string): Promise<boolean> {
         Authorization: `Bearer ${key}`,
       },
       body: JSON.stringify({
-        model: "gpt-3.5-turbo",
+        model:
+          process.env.OPENAI_CLASSIFIER_MODEL ||
+          process.env.OPENAI_RECEIPT_MODEL ||
+          "gpt-4o-mini",
+        temperature: 0,
         messages: [
-          { role: "system", content: "Determine if the following email is a purchase receipt. Respond with yes or no." },
-          { role: "user", content: text.slice(0, 4000) },
+          {
+            role: "system",
+            content:
+              "You decide whether an email either contains a purchase receipt or clearly links to one. " +
+              "Answer 'yes' when the message references an order, invoice, or purchase and includes strong signals such as " +
+              "currency amounts (e.g., $23.45), order or receipt numbers, or buttons/links like 'View order' or 'View receipt'. " +
+              "If the email is purely marketing, informational, or lacks purchase evidence, respond 'no'. Respond with exactly 'yes' or 'no'.",
+          },
+          {
+            role: "user",
+            content:
+              "Subject: Happy Place Maps order confirmation\nBody: Thanks for your purchase! Order #HPM-12345\nTotal: $27.50\nButton: View Order",
+          },
+          { role: "assistant", content: "yes" },
+          {
+            role: "user",
+            content:
+              "Subject: Storage payment receipt\nBody: Receipt Number 67890\nTotal Paid: $88.00 USD\nBalance: $0.00",
+          },
+          { role: "assistant", content: "yes" },
+          {
+            role: "user",
+            content:
+              "Subject: Summer deals are here!\nBody: Save 20% on your next order. View our catalogue for more details.",
+          },
+          { role: "assistant", content: "no" },
+          { role: "user", content: text.slice(0, 6000) },
         ],
         max_tokens: 1,
       }),
@@ -222,8 +385,11 @@ async function processMessage(
   gmail: any,
   userId: string,
   merchant: string,
-  messageId: string
+  messageId: string,
+  processedLabelId?: string | null
 ): Promise<void> {
+  let shouldLabel = false;
+  let markRead = false;
   let full;
   try {
     full = await withRetry(
@@ -239,179 +405,216 @@ async function processMessage(
     return;
   }
 
-  const payload = full.data.payload || {};
-  const headers = payload.headers || [];
-  const subject = headers.find((h: any) => (h.name || "").toLowerCase() === "subject")?.value || "";
-  const from = headers.find((h: any) => (h.name || "").toLowerCase() === "from")?.value || "";
-
-  const text = extractText(payload);
-  const combined = `${subject}\n${text}`;
-  const isReceipt = await isReceiptLLM(combined);
-  if (!isReceipt) return;
-  let parsed: ParsedReceipt | null = null;
-  let fromPdf = false;
-
-  const pdfPart = findPdfPart(payload);
-  if (pdfPart) {
-    let buf: Buffer | null = null;
-    if (pdfPart.body?.attachmentId) {
-      const att = await gmail.users.messages.attachments.get({
-        userId: "me",
-        messageId,
-        id: pdfPart.body.attachmentId,
-      });
-      const data = att.data.data as string | undefined;
-      if (data) buf = b64ToBuf(data);
-    } else if (pdfPart.body?.data) {
-      buf = b64ToBuf(pdfPart.body.data);
+  try {
+    const payload = full.data.payload || {};
+    const headers = payload.headers || [];
+    const subject = headers.find((h: any) => (h.name || "").toLowerCase() === "subject")?.value || "";
+    const from = headers.find((h: any) => (h.name || "").toLowerCase() === "from")?.value || "";
+  
+    const text = extractText(payload);
+    const combined = `${subject}\n${text}`;
+    const heuristicHit = hasReceiptIndicators(combined);
+    let isReceipt = heuristicHit;
+    if (!isReceipt) {
+      isReceipt = await isReceiptLLM(combined);
     }
-    if (buf) {
-      parsed = await parsePdf(buf);
-      fromPdf = true;
+    if (!isReceipt) {
+      shouldLabel = true;
+      return;
     }
-  }
-
-  if (!parsed) {
-    parsed = naiveParse(combined, from);
-  }
-
-  let receiptLink: string | null = null;
-
-  let {
-    merchant: m,
-    order_id,
-    purchase_date,
-    total_cents,
-    tax_cents,
-    shipping_cents,
-  } = parsed as any;
-
-  let needsReceipt =
-    !m ||
-    m === "unknown" ||
-    !order_id ||
-    !purchase_date ||
-    total_cents == null ||
-    tax_cents == null ||
-    shipping_cents == null;
-
-  if (needsReceipt) {
-    receiptLink = await findReceiptLink(payload, from);
-    if (receiptLink) {
-      (full.data as any).receipt_link = receiptLink;
-      const linkParsed = await fetchReceiptFromLink(receiptLink, {
-        user_id: userId,
-        message_id: messageId,
-        merchant: m || merchant,
-        subject,
-        from,
-      });
-      if (linkParsed) {
-        if ((!m || m === "unknown") && linkParsed.merchant) {
-          m = linkParsed.merchant.toLowerCase();
-          if (!(parsed as any).merchant) (parsed as any).merchant = linkParsed.merchant;
-        }
-        if (!order_id && linkParsed.order_id) {
-          order_id = linkParsed.order_id;
-          if (!(parsed as any).order_id) (parsed as any).order_id = linkParsed.order_id;
-        }
-        if (!purchase_date && linkParsed.purchase_date) {
-          purchase_date = linkParsed.purchase_date;
-          if (!(parsed as any).purchase_date)
-            (parsed as any).purchase_date = linkParsed.purchase_date;
-        }
-        if (total_cents == null && linkParsed.total_cents != null) {
-          total_cents = linkParsed.total_cents;
-          if ((parsed as any).total_cents == null)
-            (parsed as any).total_cents = linkParsed.total_cents;
-        }
-        if (tax_cents == null && (linkParsed as any).tax_cents != null) {
-          tax_cents = (linkParsed as any).tax_cents;
-          if ((parsed as any).tax_cents == null)
-            (parsed as any).tax_cents = (linkParsed as any).tax_cents;
-        }
-        if (shipping_cents == null && (linkParsed as any).shipping_cents != null) {
-          shipping_cents = (linkParsed as any).shipping_cents;
-          if ((parsed as any).shipping_cents == null)
-            (parsed as any).shipping_cents = (linkParsed as any).shipping_cents;
-        }
-        if (!(parsed as any).items && (linkParsed as any).items)
-          (parsed as any).items = (linkParsed as any).items;
+    shouldLabel = true;
+    markRead = true;
+    let parsed: ParsedReceipt | null = null;
+    let fromPdf = false;
+  
+    const pdfPart = findPdfPart(payload);
+    if (pdfPart) {
+      let buf: Buffer | null = null;
+      if (pdfPart.body?.attachmentId) {
+        const att = await gmail.users.messages.attachments.get({
+          userId: "me",
+          messageId,
+          id: pdfPart.body.attachmentId,
+        });
+        const data = att.data.data as string | undefined;
+        if (data) buf = b64ToBuf(data);
+      } else if (pdfPart.body?.data) {
+        buf = b64ToBuf(pdfPart.body.data);
+      }
+      if (buf) {
+        parsed = await parsePdf(buf);
+        fromPdf = true;
       }
     }
-  }
-
-  needsReceipt =
-    !m ||
-    m === "unknown" ||
-    !order_id ||
-    !purchase_date ||
-    total_cents == null ||
-    tax_cents == null ||
-    shipping_cents == null;
-
-  if (needsReceipt) {
-    const excerpt = (parsed as any).text_excerpt;
-    const llmText = [subject, combined, excerpt].filter(Boolean).join("\n\n");
-    const llm = await extractReceipt(llmText);
-    if (llm) {
-      if ((!m || m === "unknown") && llm.merchant) m = llm.merchant.toLowerCase();
-      if (!order_id && llm.order_id) order_id = llm.order_id;
-      if (!purchase_date && llm.purchase_date) purchase_date = llm.purchase_date;
-      if (total_cents == null && llm.total_cents != null) total_cents = llm.total_cents;
-      if (tax_cents == null && llm.tax_cents != null) tax_cents = llm.tax_cents;
-      if (shipping_cents == null && llm.shipping_cents != null)
-        shipping_cents = llm.shipping_cents;
+  
+    if (!parsed) {
+      parsed = naiveParse(combined, from);
     }
-  }
-
-  await logParseResult({
-    parser: fromPdf ? "pdf" : "naive",
-    merchant: m || "unknown",
-    order_id_found: !!order_id,
-    purchase_date_found: !!purchase_date,
-    total_cents_found: total_cents != null,
-  });
-
-  const up = await supabaseAdmin
-    .from("receipts")
-    .upsert(
-      [
-        {
+  
+    let receiptLink: string | null = null;
+  
+    let {
+      merchant: m,
+      order_id,
+      purchase_date,
+      total_cents,
+      tax_cents,
+      shipping_cents,
+    } = parsed as any;
+  
+    let needsReceipt =
+      !m ||
+      m === "unknown" ||
+      !order_id ||
+      !purchase_date ||
+      total_cents == null ||
+      tax_cents == null ||
+      shipping_cents == null;
+  
+    if (needsReceipt) {
+      receiptLink = await findReceiptLink(payload, from);
+      if (receiptLink) {
+        (full.data as any).receipt_link = receiptLink;
+        const linkParsed = await fetchReceiptFromLink(receiptLink, {
           user_id: userId,
+          message_id: messageId,
           merchant: m || merchant,
-          order_id: order_id || "",
-          purchase_date: purchase_date || null,
-          total_cents: total_cents ?? null,
-          tax_cents: tax_cents ?? null,
-          shipping_cents: shipping_cents ?? null,
-          receipt_url: receiptLink,
-          raw_json: full.data,
-        },
-      ],
-      { onConflict: "user_id,merchant,order_id,purchase_date" }
-    )
-    .select("id")
-    .single();
-
-  const receiptId = up.data?.id;
-  const items: any[] = (parsed as any).items || [];
-  if (receiptId && Array.isArray(items) && items.length > 0) {
-    const payloadItems = items.map((it) => ({
-      receipt_id: receiptId,
-      name: it.name || "",
-      qty: it.qty || 1,
-      unit_cents: it.unit_cents ?? null,
-    }));
-    await supabaseAdmin.from("line_items").delete().eq("receipt_id", receiptId);
-    await supabaseAdmin.from("line_items").insert(payloadItems);
+          subject,
+          from,
+        });
+        if (linkParsed) {
+          if ((!m || m === "unknown") && linkParsed.merchant) {
+            m = linkParsed.merchant.toLowerCase();
+            if (!(parsed as any).merchant) (parsed as any).merchant = linkParsed.merchant;
+          }
+          if (!order_id && linkParsed.order_id) {
+            order_id = linkParsed.order_id;
+            if (!(parsed as any).order_id) (parsed as any).order_id = linkParsed.order_id;
+          }
+          if (!purchase_date && linkParsed.purchase_date) {
+            purchase_date = linkParsed.purchase_date;
+            if (!(parsed as any).purchase_date)
+              (parsed as any).purchase_date = linkParsed.purchase_date;
+          }
+          if (total_cents == null && linkParsed.total_cents != null) {
+            total_cents = linkParsed.total_cents;
+            if ((parsed as any).total_cents == null)
+              (parsed as any).total_cents = linkParsed.total_cents;
+          }
+          if (tax_cents == null && (linkParsed as any).tax_cents != null) {
+            tax_cents = (linkParsed as any).tax_cents;
+            if ((parsed as any).tax_cents == null)
+              (parsed as any).tax_cents = (linkParsed as any).tax_cents;
+          }
+          if (shipping_cents == null && (linkParsed as any).shipping_cents != null) {
+            shipping_cents = (linkParsed as any).shipping_cents;
+            if ((parsed as any).shipping_cents == null)
+              (parsed as any).shipping_cents = (linkParsed as any).shipping_cents;
+          }
+          if (!(parsed as any).items && (linkParsed as any).items)
+            (parsed as any).items = (linkParsed as any).items;
+        }
+      }
+    }
+  
+    needsReceipt =
+      !m ||
+      m === "unknown" ||
+      !order_id ||
+      !purchase_date ||
+      total_cents == null ||
+      tax_cents == null ||
+      shipping_cents == null;
+  
+    if (needsReceipt) {
+      const excerpt = (parsed as any).text_excerpt;
+      const llmText = [subject, combined, excerpt].filter(Boolean).join("\n\n");
+      const llm = await extractReceipt(llmText);
+      if (llm) {
+        if ((!m || m === "unknown") && llm.merchant) m = llm.merchant.toLowerCase();
+        if (!order_id && llm.order_id) order_id = llm.order_id;
+        if (!purchase_date && llm.purchase_date) purchase_date = llm.purchase_date;
+        if (total_cents == null && llm.total_cents != null) total_cents = llm.total_cents;
+        if (tax_cents == null && llm.tax_cents != null) tax_cents = llm.tax_cents;
+        if (shipping_cents == null && llm.shipping_cents != null)
+          shipping_cents = llm.shipping_cents;
+      }
+    }
+  
+    await logParseResult({
+      parser: fromPdf ? "pdf" : "naive",
+      merchant: m || "unknown",
+      order_id_found: !!order_id,
+      purchase_date_found: !!purchase_date,
+      total_cents_found: total_cents != null,
+    });
+  
+    const up = await supabaseAdmin
+      .from("receipts")
+      .upsert(
+        [
+          {
+            user_id: userId,
+            merchant: m || merchant,
+            order_id: order_id || "",
+            purchase_date: purchase_date || null,
+            total_cents: total_cents ?? null,
+            tax_cents: tax_cents ?? null,
+            shipping_cents: shipping_cents ?? null,
+            receipt_url: receiptLink,
+            raw_json: full.data,
+          },
+        ],
+        { onConflict: "user_id,merchant,order_id,purchase_date" }
+      )
+      .select("id")
+      .single();
+  
+    const receiptId = up.data?.id;
+    const items: any[] = (parsed as any).items || [];
+    if (receiptId && Array.isArray(items) && items.length > 0) {
+      const payloadItems = items.map((it) => ({
+        receipt_id: receiptId,
+        name: it.name || "",
+        qty: it.qty || 1,
+        unit_cents: it.unit_cents ?? null,
+      }));
+      await supabaseAdmin.from("line_items").delete().eq("receipt_id", receiptId);
+      await supabaseAdmin.from("line_items").insert(payloadItems);
+    }
+  } finally {
+    await modifyMessageLabels(
+      gmail,
+      messageId,
+      processedLabelId ?? null,
+      markRead,
+      shouldLabel
+    );
   }
+}
 
-  await gmail.users.messages.modify({
-    userId: "me",
-    id: messageId,
-    requestBody: { removeLabelIds: ["UNREAD"] },
-  });
+async function modifyMessageLabels(
+  gmail: any,
+  messageId: string,
+  processedLabelId: string | null,
+  markRead: boolean,
+  shouldLabel: boolean
+) {
+  const shouldModify = markRead || (shouldLabel && processedLabelId);
+  if (!shouldModify) return;
+  const requestBody: Record<string, any> = {};
+  if (markRead) requestBody.removeLabelIds = ["UNREAD"];
+  if (shouldLabel && processedLabelId) requestBody.addLabelIds = [processedLabelId];
+  if (Object.keys(requestBody).length === 0) return;
+  try {
+    await gmail.users.messages.modify({
+      userId: "me",
+      id: messageId,
+      requestBody,
+    });
+  } catch (err) {
+    console.warn("[gmail] failed to modify labels", err);
+  }
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -431,6 +634,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(500).json({ ok: false, error: error?.message });
   }
 
+  const processedLabelCache = new Map<string, string | null>();
+
   for (const row of data) {
     const userId = row.user_id as string;
     const merchant = row.merchant as string;
@@ -438,7 +643,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!tokens) continue;
     const gmail = google.gmail({ version: "v1", auth: tokens.client });
 
-    const query = `from:${merchant} is:unread`;
+    let processedLabelId = processedLabelCache.get(userId);
+    if (processedLabelId === undefined) {
+      processedLabelId = await ensureProcessedLabel(gmail);
+      processedLabelCache.set(userId, processedLabelId ?? null);
+    }
+
+    const terms = [`from:${merchant}`];
+    if (processedLabelId) {
+      terms.push(`-label:${PROCESSED_LABEL_NAME}`);
+    }
+    const query = terms.join(" ");
     const list = await withRetry(
       () => gmail.users.messages.list({ userId: "me", q: query }),
       "users.messages.list"
@@ -446,7 +661,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const msgs = list.data.messages || [];
     for (const msg of msgs) {
       if (!msg.id) continue;
-      await processMessage(gmail, userId, merchant, msg.id);
+      await processMessage(gmail, userId, merchant, msg.id, processedLabelId);
     }
   }
 

--- a/lib/llm/extract-receipt-link.ts
+++ b/lib/llm/extract-receipt-link.ts
@@ -1,13 +1,30 @@
 // lib/llm/extract-receipt-link.ts
-export default async function extractReceiptLink(urls: string[]): Promise<string | null> {
-  if (!Array.isArray(urls) || urls.length === 0) return null;
+export interface ReceiptLinkCandidate {
+  url: string;
+  anchorText?: string;
+}
+
+export default async function extractReceiptLink(
+  links: ReceiptLinkCandidate[]
+): Promise<string | null> {
+  if (!Array.isArray(links) || links.length === 0) return null;
+  const urls = links.map((link) => link.url);
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) return urls[0] ?? null;
   try {
-    const prompt =
-      "Choose the URL most likely to lead to a purchase receipt from the following list. " +
-      "Respond with the single URL or 'none' if none seem like receipts.\n" +
-      urls.map((u, i) => `${i + 1}. ${u}`).join("\n");
+    const promptLines = [
+      "Choose the URL most likely to lead to a purchase receipt from the following list.",
+      "Each candidate includes the anchor/button text from the email.",
+      "Respond with the single URL that should be fetched, or 'none' if nothing is relevant.",
+      "",
+      links
+        .map((link, i) => {
+          const anchor = link.anchorText?.trim() || "(no anchor text)";
+          return `${i + 1}. URL: ${link.url}\n   Anchor: ${anchor}`;
+        })
+        .join("\n"),
+    ];
+    const prompt = promptLines.join("\n");
     const resp = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: {
@@ -26,9 +43,21 @@ export default async function extractReceiptLink(urls: string[]): Promise<string
     const data = await resp.json().catch(() => null);
     const answer = data?.choices?.[0]?.message?.content?.trim() || "";
     if (!answer) return null;
+    const lower = answer.toLowerCase();
+    if (lower.includes("none")) return null;
     const found = urls.find((u) => answer.includes(u));
     if (found) return found;
-    return null;
+    const urlMatch = answer.match(/https?:\/\/[^\s]+/);
+    if (urlMatch) {
+      const match = urls.find((u) => u === urlMatch[0]);
+      if (match) return match;
+    }
+    const indexMatch = answer.match(/\b(\d+)\b/);
+    if (indexMatch) {
+      const idx = parseInt(indexMatch[1], 10) - 1;
+      if (idx >= 0 && idx < urls.length) return urls[idx];
+    }
+    return urls[0] ?? null;
   } catch {
     return urls[0] ?? null;
   }


### PR DESCRIPTION
## Summary
- scan approved merchants' mailboxes for both read and unread messages using a dedicated processed label
- strengthen receipt detection with heuristic keyword/amount checks and an improved LLM prompt
- expand receipt link handling to consider anchor text when scoring and selecting URLs

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68c75d4bfba48331a243992d515451c6