### PR TITLE
Update Gmail scope to support modifying messages

### DIFF
--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -5,7 +5,7 @@ const CLIENT_ID = process.env.GMAIL_CLIENT_ID || "";
 const CLIENT_SECRET = process.env.GMAIL_CLIENT_SECRET || "";
 const REDIRECT_URI = process.env.GMAIL_REDIRECT_URI || "";
 
-const SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"];
+const SCOPES = ["https://www.googleapis.com/auth/gmail.modify"];
 
 function oauthClient() {
   return new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);


### PR DESCRIPTION
## Summary
- change the Gmail OAuth scope to gmail.modify so the integration can update labels and message states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68c8bb78b3b083318ef1acede79df532