### PR TITLE
Expand Gmail OAuth scopes to include label management

### DIFF
--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -5,7 +5,10 @@ const CLIENT_ID = process.env.GMAIL_CLIENT_ID || "";
 const CLIENT_SECRET = process.env.GMAIL_CLIENT_SECRET || "";
 const REDIRECT_URI = process.env.GMAIL_REDIRECT_URI || "";
 
-const SCOPES = ["https://www.googleapis.com/auth/gmail.modify"];
+const SCOPES = [
+  "https://www.googleapis.com/auth/gmail.modify",
+  "https://www.googleapis.com/auth/gmail.labels",
+];
 
 function oauthClient() {
   return new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);


### PR DESCRIPTION
## Summary
- add the gmail.labels scope to the OAuth client configuration so new tokens receive label access

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c8bef020c083318ccdec9ab20b1470