### PR TITLE
Improve Gmail scope handling and add reauth support

### DIFF
--- a/api/connectors/gmail/reauthorize.ts
+++ b/api/connectors/gmail/reauthorize.ts
@@ -1,0 +1,61 @@
+// api/connectors/gmail/reauthorize.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { getGmailAuthUrl } from "../../../lib/gmail.js";
+import { supabaseAdmin } from "../../../lib/supabase-admin.js";
+
+function parseUser(req: VercelRequest): string {
+  if (typeof req.body === "string") {
+    try {
+      const parsed = JSON.parse(req.body);
+      if (parsed && typeof parsed === "object" && typeof parsed.user === "string") {
+        const trimmed = parsed.user.trim();
+        if (trimmed) return trimmed;
+      }
+    } catch {
+      // ignore parse errors and fall through
+    }
+  }
+  if (req.body && typeof req.body === "object") {
+    const candidate = (req.body as any).user;
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  }
+  const fromQuery = req.query.user;
+  if (typeof fromQuery === "string" && fromQuery.trim()) return fromQuery.trim();
+  return "";
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).end();
+  }
+
+  try {
+    const user = parseUser(req);
+    if (!user) {
+      return res.status(400).json({ ok: false, error: "missing user" });
+    }
+
+    await supabaseAdmin
+      .from("gmail_tokens")
+      .upsert(
+        {
+          user_id: user,
+          refresh_token: null,
+          access_token: null,
+          access_token_expires_at: null,
+          granted_scopes: [],
+          status: "reauth_required",
+        },
+        { onConflict: "user_id" }
+      );
+
+    const state = Buffer.from(JSON.stringify({ user }), "utf8").toString("base64url");
+    const url = getGmailAuthUrl(state);
+
+    return res.status(200).json({ ok: true, url });
+  } catch (err) {
+    console.error("[gmail] reauthorize failed", err);
+    return res.status(500).json({ ok: false, error: "internal_error" });
+  }
+}

--- a/api/gmail/callback.ts
+++ b/api/gmail/callback.ts
@@ -1,6 +1,6 @@
 // api/gmail/callback.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { exchangeCodeForTokens } from "../../lib/gmail.js";
+import { createOAuthClient, exchangeCodeForTokens } from "../../lib/gmail.js";
 import { supabaseAdmin } from "../../lib/supabase-admin.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -20,6 +20,31 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const tokens = await exchangeCodeForTokens(code);
     const expires = tokens.expiry_date ? new Date(tokens.expiry_date).toISOString() : null;
+
+    const client = createOAuthClient();
+    client.setCredentials(tokens);
+
+    let grantedScopes: string[] = [];
+    if (tokens.access_token) {
+      try {
+        const info = await client.getTokenInfo(tokens.access_token);
+        const scopes = Array.isArray(info?.scopes)
+          ? info.scopes
+          : typeof (info as any)?.scope === "string"
+          ? (info as any).scope.split(/\s+/)
+          : [];
+        grantedScopes = Array.from(
+          new Set(
+            scopes
+              .map((scope: any) => (typeof scope === "string" ? scope.trim() : ""))
+              .filter((scope: string) => scope.length > 0)
+          )
+        );
+      } catch (err) {
+        console.warn("[gmail] failed to fetch granted scopes during callback", err);
+      }
+    }
+
     await supabaseAdmin
       .from("gmail_tokens")
       .upsert(
@@ -28,9 +53,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           refresh_token: tokens.refresh_token,
           access_token: tokens.access_token,
           access_token_expires_at: expires,
+          granted_scopes: grantedScopes,
+          status: "active",
         },
         { onConflict: "user_id" }
       );
+
+    if (grantedScopes.length > 0) {
+      const maskedUser =
+        user.length > 8 ? `${user.slice(0, 4)}…${user.slice(-2)}` : user || "unknown";
+      console.info("[gmail] linked user scopes", {
+        user: maskedUser,
+        scopes: grantedScopes,
+      });
+    }
 
     res.redirect(302, `/api/gmail/merchants-ui?user=${encodeURIComponent(user)}`);
   } catch (e: any) {

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -10,12 +10,12 @@ const SCOPES = [
   "https://www.googleapis.com/auth/gmail.labels",
 ];
 
-function oauthClient() {
+export function createOAuthClient() {
   return new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
 }
 
 export function getGmailAuthUrl(state: string): string {
-  const client = oauthClient();
+  const client = createOAuthClient();
   return client.generateAuthUrl({
     access_type: "offline",
     scope: SCOPES,
@@ -25,7 +25,7 @@ export function getGmailAuthUrl(state: string): string {
 }
 
 export async function exchangeCodeForTokens(code: string) {
-  const client = oauthClient();
+  const client = createOAuthClient();
   const { tokens } = await client.getToken(code);
   return tokens;
 }


### PR DESCRIPTION
## Summary
- gate processed-label creation behind a GMAIL_LABELING_ENABLED flag and return HTTP 428 reauth errors when Gmail rejects write operations for insufficient scope
- persist granted Gmail scopes during OAuth callback and expose them via getAccessToken for runtime checks
- add a POST /connectors/gmail/reauthorize endpoint that clears stored tokens and forces a new consent flow

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68c9a6c2b1248331bcec5011c596f024