### PR TITLE
Handle Gmail reauth and restore merchant discovery

### DIFF
--- a/api/gmail/merchants-ui.ts
+++ b/api/gmail/merchants-ui.ts
@@ -40,6 +40,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const timeout = setTimeout(() => controller.abort(), 30000);
         const r = await fetch('/api/gmail/merchants?user=' + encodeURIComponent(user), { signal: controller.signal });
         clearTimeout(timeout);
+        if (r.status === 428) {
+          window.location.href = '/api/gmail/ui?user=' + encodeURIComponent(user);
+          return;
+        }
+        if (!r.ok) {
+          throw new Error('failed to load');
+        }
         const data = await r.json();
         if (!data.merchants || data.merchants.length === 0) {
           list.innerHTML = '<p>No merchants found.</p>';


### PR DESCRIPTION
## Summary
- add a Gmail token preflight to the merchants API and return 428 when reauth is required
- update the merchants UI to redirect users to relink Gmail when the API signals reauth
- allow reusing fetched tokens in the Gmail scanner and restore the discovery query/regex

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68ca080632788331858b4c7b9eb147ef