### PR TITLE
Implement Gmail receipt discovery and ingest pipeline

### DIFF
--- a/lib/gmail-scan.ts
+++ b/lib/gmail-scan.ts
@@ -107,6 +107,14 @@ export async function getAccessToken(
   };
 }
 
+const HEADERS = ["From", "Subject", "Date"];
+
+const AGGREGATOR_BUCKETS: { domain: string; label: string }[] = [
+  { domain: "shopify.com", label: "Shopify Sellers" },
+  { domain: "squareup.com", label: "Square Sellers" },
+  { domain: "paypal.com", label: "PayPal Receipts" },
+];
+
 function extractDomain(from: string): string | null {
   const match = from.match(/@([^>\s]+)/);
   if (!match) return null;
@@ -121,129 +129,259 @@ function extractDisplayName(from: string): string | null {
 }
 
 function extractMerchantFromSubject(subject: string): string | null {
-  const m = subject.match(/\bfrom\s+([^:-]+)/i) || subject.match(/\bat\s+([^:-]+)/i);
+  const m =
+    subject.match(/\bfrom\s+([^:-]+)/i) || subject.match(/\bat\s+([^:-]+)/i);
   return m ? m[1].trim() : null;
 }
 
-function normalizeMerchant(value: string): string {
-  return value.trim().replace(/^["']+|["']+$/g, "").toLowerCase();
+function normalizeWhitespace(value: string): string {
+  return value
+    .replace(/["']/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
-const GENERIC_DOMAINS = ["shopify.com"];
+function bucketForAggregator(domain: string | null): { domain: string; name: string } | null {
+  if (!domain) return null;
+  for (const bucket of AGGREGATOR_BUCKETS) {
+    if (domain === bucket.domain || domain.endsWith(`.${bucket.domain}`)) {
+      return { domain: bucket.domain, name: bucket.label };
+    }
+  }
+  return null;
+}
 
-function isGenericDomain(domain: string): boolean {
-  return GENERIC_DOMAINS.some((d) => domain === d || domain.endsWith(`.${d}`));
+function toDisplayName(domain: string, fallback?: string | null): string {
+  const parts = domain.replace(/\.com$|\.net$|\.org$|\.co$|\.io$/i, "").split(".");
+  const base = parts[0] || fallback || domain;
+  return base
+    .split(/[-_]/)
+    .map((p) => (p ? p[0].toUpperCase() + p.slice(1) : ""))
+    .filter(Boolean)
+    .join(" ");
+}
+
+function buildMerchantName(
+  domain: string | null,
+  from: string,
+  subject: string
+): { domain: string | null; name: string | null } {
+  if (domain) {
+    const bucket = bucketForAggregator(domain);
+    if (bucket) {
+      return { domain: bucket.domain, name: bucket.name };
+    }
+  }
+
+  const display = normalizeWhitespace(extractDisplayName(from) || "");
+  if (display) {
+    return { domain, name: display };
+  }
+
+  if (domain) {
+    return { domain, name: toDisplayName(domain) };
+  }
+
+  const subjectMerchant = extractMerchantFromSubject(subject);
+  if (subjectMerchant) {
+    return { domain: null, name: normalizeWhitespace(subjectMerchant) };
+  }
+  return { domain, name: null };
+}
+
+function computeDateWindow(monthsRaw?: string | number | null): string {
+  const months = Number.parseInt(String(monthsRaw ?? ""), 10);
+  const fallbackMonths = Number.isFinite(months) && months > 0 ? months : 12;
+  const since = new Date();
+  since.setMonth(since.getMonth() - fallbackMonths);
+  const yyyy = since.getFullYear();
+  const mm = String(since.getMonth() + 1).padStart(2, "0");
+  const dd = String(since.getDate()).padStart(2, "0");
+  return `${yyyy}/${mm}/${dd}`;
+}
+
+type Gmail = ReturnType<typeof google.gmail>;
+
+interface HeaderLookup {
+  from?: string;
+  subject?: string;
+  date?: string;
+}
+
+async function fetchMetadata(
+  gmail: Gmail,
+  id: string
+): Promise<HeaderLookup | null> {
+  try {
+    const resp = await withRetry(
+      () =>
+        gmail.users.messages.get({
+          userId: "me",
+          id,
+          format: "metadata",
+          metadataHeaders: HEADERS,
+        }),
+      "users.messages.get"
+    );
+    const headers = resp.data.payload?.headers || [];
+    const lookup: HeaderLookup = {};
+    for (const h of headers) {
+      const name = (h.name || "").toLowerCase();
+      if (name === "from") lookup.from = h.value || undefined;
+      if (name === "subject") lookup.subject = h.value || undefined;
+      if (name === "date") lookup.date = h.value || undefined;
+    }
+    return lookup;
+  } catch (err) {
+    console.warn("[gmail][discovery] metadata fetch failed", err);
+    return null;
+  }
+}
+
+async function listMessages(
+  gmail: Gmail,
+  query: string,
+  skipIds: Set<string>
+): Promise<{ ids: string[]; headers: Map<string, HeaderLookup> }> {
+  const ids: string[] = [];
+  const headers = new Map<string, HeaderLookup>();
+  let pageToken: string | undefined;
+  do {
+    const resp: any = await withRetry(
+      () =>
+        gmail.users.messages.list(
+          {
+            userId: "me",
+            q: query,
+            maxResults: 500,
+            pageToken,
+            format: "metadata",
+            metadataHeaders: HEADERS,
+          } as any
+        ),
+      "users.messages.list"
+    );
+    const messages = (resp?.data?.messages as any[]) || [];
+    for (const message of messages) {
+      const id = message.id;
+      if (!id || skipIds.has(id)) continue;
+      ids.push(id);
+      if (Array.isArray((message as any).payload?.headers)) {
+        const lookup: HeaderLookup = {};
+        for (const h of (message as any).payload.headers) {
+          const name = (h.name || "").toLowerCase();
+          if (name === "from") lookup.from = h.value || undefined;
+          if (name === "subject") lookup.subject = h.value || undefined;
+          if (name === "date") lookup.date = h.value || undefined;
+        }
+        if (lookup.from || lookup.subject) headers.set(id, lookup);
+      }
+    }
+    pageToken = resp?.data?.nextPageToken || undefined;
+    if (!pageToken) break;
+  } while (true);
+
+  const missingIds = ids.filter((id) => !headers.has(id));
+  if (missingIds.length > 0) {
+    await Promise.all(
+      missingIds.map(async (id) => {
+        const meta = await fetchMetadata(gmail, id);
+        if (meta) headers.set(id, meta);
+      })
+    );
+  }
+
+  return { ids, headers };
+}
+
+export type MerchantDiscoverySource = "smartlabel" | "heuristic";
+
+export interface MerchantDiscoveryItem {
+  name: string;
+  domain: string;
+  est_count: number;
+  source: MerchantDiscoverySource;
+}
+
+export interface MerchantDiscoveryResult {
+  merchants: MerchantDiscoveryItem[];
 }
 
 export async function scanGmailMerchants(
   userId: string,
   tokensOverride?: GmailAccessTokenResult | null
-): Promise<string[]> {
+): Promise<MerchantDiscoveryResult> {
   const tokens = tokensOverride ?? (await getAccessToken(userId));
-  if (!tokens) return [];
+  if (!tokens) return { merchants: [] };
   if (tokens.status && String(tokens.status).toLowerCase() === "reauth_required") {
-    return [];
+    return { merchants: [] };
   }
 
-  const { client } = tokens;
-  const gmail = google.gmail({ version: "v1", auth: client });
+  const gmail = google.gmail({ version: "v1", auth: tokens.client });
+  const dateStr = computeDateWindow(process.env.GMAIL_DISCOVERY_MONTHS);
 
-  const since = new Date();
-  since.setMonth(since.getMonth() - 12);
-  const dateStr = `${since.getFullYear()}/${String(since.getMonth() + 1).padStart(2, "0")}/${String(
-    since.getDate()
-  ).padStart(2, "0")}`;
-  const q = [
-    'subject:(receipt OR order OR invoice OR purchase OR bill OR transaction OR payment OR confirmation OR statement OR "your order" OR "receipt for")',
-    "(category:updates OR label:purchases)",
+  const subjectClause =
+    'subject:(receipt OR "receipt for" OR order OR "your order" OR invoice OR purchase OR bill OR transaction OR payment OR confirmation OR statement)';
+
+  const q1 = [
+    subjectClause,
+    "(label:^smartlabel_receipt OR category:updates)",
     `after:${dateStr}`,
   ].join(" ");
-  const keywordRegex =
-    /\b(receipt(?:\s+for)?|your\s+order|invoice|purchase|bill|transaction|payment|confirmation|statement|order)\b/i;
+  const q2 = [subjectClause, "category:updates", `after:${dateStr}`].join(" ");
 
-  const merchants = new Set<string>();
-  let pageToken: string | undefined;
-  let totalScanned = 0;
-  let qualifying = 0;
+  const aggregates = new Map<string, MerchantDiscoveryItem>();
+  const seenIds = new Set<string>();
 
-  const MAX_QUALIFYING = 100;
-  const MAX_SCANNED = 500;
-
-  while (totalScanned < MAX_SCANNED && qualifying < MAX_QUALIFYING) {
-    const res = await withRetry(
-      () =>
-        gmail.users.messages.list({
-          userId: "me",
-          labelIds: ["INBOX"],
-          q,
-          maxResults: Math.min(MAX_SCANNED - totalScanned, 500),
-          pageToken,
-        }),
-      "users.messages.list"
-    );
-
-    const messages = res.data.messages || [];
-    if (messages.length === 0) break;
-
-    // Collect all message IDs for this page
-    const ids = messages.map((m) => m.id).filter((id): id is string => !!id);
-    const BATCH_SIZE = 10; // limit concurrent Gmail requests
-
-    for (
-      let i = 0,
-      len = ids.length;
-      i < len && totalScanned < MAX_SCANNED && qualifying < MAX_QUALIFYING;
-      i += BATCH_SIZE
-    ) {
-      const batchIds = ids.slice(i, i + BATCH_SIZE);
-      const metas = await Promise.all(
-        batchIds.map((id) =>
-          withRetry(
-            () =>
-              gmail.users.messages.get({
-                userId: "me",
-                id,
-                format: "metadata",
-                metadataHeaders: ["From", "Subject"],
-              }),
-            "users.messages.get"
-          ).catch(() => null)
-        )
-      );
-
-      for (const meta of metas) {
-        if (!meta) continue;
-        const headers = meta.data.payload?.headers || [];
-        const from = headers.find((h: any) => (h.name || "").toLowerCase() === "from")?.value;
-        const subject = headers
-          .find((h: any) => (h.name || "").toLowerCase() === "subject")
-          ?.value;
-        totalScanned++;
-        if (!from || !subject || !keywordRegex.test(subject)) continue;
-        qualifying++;
-        const domain = extractDomain(from);
-        const display = extractDisplayName(from);
-        if (domain && /amazon\./i.test(domain)) continue;
-        let merchant = domain;
-        if (!merchant || isGenericDomain(merchant)) {
-          merchant = display || extractMerchantFromSubject(subject);
+  const runQuery = async (query: string, source: MerchantDiscoverySource) => {
+    const { ids, headers } = await listMessages(gmail, query, seenIds);
+    for (const id of ids) seenIds.add(id);
+    console.info("[gmail][discovery]", { q: query, source, found: ids.length });
+    for (const id of ids) {
+      const header = headers.get(id);
+      if (!header) continue;
+      const from = header.from || "";
+      const subject = header.subject || "";
+      const domain = extractDomain(from);
+      const { domain: mappedDomain, name } = buildMerchantName(domain, from, subject);
+      if (!mappedDomain || !name) continue;
+      const domainKey = mappedDomain.toLowerCase();
+      const existing = aggregates.get(domainKey);
+      if (existing) {
+        existing.est_count += 1;
+        if (existing.source !== "smartlabel" && source === "smartlabel") {
+          existing.source = "smartlabel";
         }
-        if (merchant) {
-          merchants.add(normalizeMerchant(merchant));
-        }
-        if (totalScanned >= MAX_SCANNED || qualifying >= MAX_QUALIFYING) break;
+        if (!existing.name && name) existing.name = name;
+      } else {
+        aggregates.set(domainKey, {
+          domain: domainKey,
+          name,
+          est_count: 1,
+          source,
+        });
       }
     }
+    return ids.length;
+  };
 
-    if (
-      totalScanned >= MAX_SCANNED ||
-      qualifying >= MAX_QUALIFYING ||
-      !res.data.nextPageToken
-    )
-      break;
-    pageToken = res.data.nextPageToken;
+  const firstCount = await runQuery(q1, "smartlabel");
+  if (firstCount === 0) {
+    await runQuery(q2, "heuristic");
+  } else {
+    await runQuery(q2, "heuristic");
   }
 
-  return Array.from(merchants);
+  const merchants = Array.from(aggregates.values()).sort(
+    (a, b) => b.est_count - a.est_count
+  );
+
+  console.info("[gmail][discovery]", {
+    event: "discovery_complete",
+    user_id: userId,
+    merchants: merchants.length,
+  });
+
+  return { merchants };
 }
 


### PR DESCRIPTION
## Summary
- upgrade Gmail discovery to use smartlabel/category queries, aggregate by domain, and log discovery metrics
- update the merchants API to surface structured discovery results and persist estimated counts/sources
- refactor Gmail ingest to use merchant-scoped queries, normalize parsed receipts with dedupe hashes, and capture telemetry

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68ca0d434ef08331bcaf9e6128a1bf1c