### PR TITLE
Update Gmail auth helper to embed user state

### DIFF
--- a/api/connectors/gmail/reauthorize.ts
+++ b/api/connectors/gmail/reauthorize.ts
@@ -79,8 +79,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
     }
 
-    const state = Buffer.from(JSON.stringify({ user }), "utf8").toString("base64url");
-    const url = getGmailAuthUrl(state);
+    const url = getGmailAuthUrl({ user });
+    // Rely on shared helper to keep OAuth state JSON encoded for consistent callback handling.
 
     return res.status(200).json({ ok: true, url });
   } catch (err) {

--- a/api/gmail/auth.ts
+++ b/api/gmail/auth.ts
@@ -1,4 +1,6 @@
 // api/gmail/auth.ts
+// Assumes caller validates the user identity upstream; trade-off keeps handler simple and focused on
+// generating an OAuth link while relying on state payload for downstream verification.
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { getGmailAuthUrl } from "../../lib/gmail.js";
 
@@ -7,8 +9,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const user = (req.query.user as string) || "";
     if (!user) return res.status(400).json({ ok: false, error: "missing user" });
 
-    const state = Buffer.from(JSON.stringify({ user })).toString("base64url");
-    const url = getGmailAuthUrl(state);
+    const url = getGmailAuthUrl({ user });
     res.redirect(302, url);
   } catch (e: any) {
     res.status(400).json({ ok: false, error: String(e?.message || e) });

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -1,4 +1,6 @@
 // lib/gmail.ts
+// Assumes Gmail integrations always need offline access refresh tokens; trade-off is consistently
+// generating explicit OAuth params (no Base64 encoding) to simplify callback validation logic.
 import { google } from "googleapis";
 
 const CLIENT_ID = process.env.GMAIL_CLIENT_ID || "";
@@ -14,13 +16,14 @@ export function createOAuthClient() {
   return new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
 }
 
-export function getGmailAuthUrl(state: string): string {
+export function getGmailAuthUrl({ user }: { user: string }): string {
   const client = createOAuthClient();
   return client.generateAuthUrl({
     access_type: "offline",
     scope: SCOPES,
-    state,
+    state: JSON.stringify({ user }),
     prompt: "consent",
+    include_granted_scopes: false,
   });
 }
 


### PR DESCRIPTION
## Summary
- update the Gmail OAuth helper to accept a user id payload and ensure JSON state plus required consent parameters
- route the regular Gmail auth endpoint through the helper so it no longer base64-encodes state on its own
- align the reauthorize endpoint with the shared helper for consistent state handling

## File-by-file
- lib/gmail.ts: accept `{ user }` input, force offline consent flags, and encode state as JSON.
- api/gmail/auth.ts: request auth URLs via the updated helper using the provided user id.
- api/connectors/gmail/reauthorize.ts: reuse the helper to build the reauth URL and note the JSON state behavior.

## Testing
- ./node_modules/.bin/tsc --noEmit --pretty false

------
https://chatgpt.com/codex/tasks/task_b_68d18a90d1a88331bf3ff0b44068d7c5