### PR TITLE
Handle Gmail callback state JSON and scope capture

### DIFF
--- a/api/gmail/callback.test.ts
+++ b/api/gmail/callback.test.ts
@@ -1,0 +1,121 @@
+// api/gmail/callback.test.ts
+// Assumes callback handler interactions can be isolated via module stubs; trade-off is manually
+// managing fake Supabase and Gmail helpers so we can assert state validation logic without hitting real services.
+import test, { mock } from "node:test";
+import assert from "node:assert";
+import { createRequire } from "node:module";
+
+process.env.SUPABASE_URL = "http://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+const require = createRequire(import.meta.url);
+
+const gmailModulePath = require.resolve("../../lib/gmail.js");
+const exchangeCodeForTokensSpy = mock.fn(async (_code: string): Promise<any> => {
+  throw new Error("exchangeCodeForTokens not stubbed");
+});
+const getTokenInfoSpy = mock.fn(async (_token: string): Promise<any> => {
+  throw new Error("getTokenInfo not stubbed");
+});
+
+require.cache[gmailModulePath] = {
+  id: gmailModulePath,
+  filename: gmailModulePath,
+  loaded: true,
+  exports: {
+    exchangeCodeForTokens: exchangeCodeForTokensSpy,
+    getTokenInfo: getTokenInfoSpy,
+  },
+} as any;
+
+const { supabaseAdmin } = await import("../../lib/supabase-admin.js");
+(supabaseAdmin as any).from = () => ({
+  select: () => ({
+    eq: () => ({
+      maybeSingle: async () => ({ data: null, error: null }),
+    }),
+  }),
+  upsert: async () => ({ error: null }),
+});
+
+const { default: handler } = await import("./callback.js");
+
+function resetSpies() {
+  exchangeCodeForTokensSpy.mock.resetCalls();
+  exchangeCodeForTokensSpy.mock.mockImplementation(async (_code: string): Promise<any> => {
+    throw new Error("exchangeCodeForTokens not stubbed");
+  });
+  getTokenInfoSpy.mock.resetCalls();
+  getTokenInfoSpy.mock.mockImplementation(async (_token: string): Promise<any> => {
+    throw new Error("getTokenInfo not stubbed");
+  });
+}
+
+function createMockResponse() {
+  const record: {
+    statusCode: number | null;
+    body: any;
+    redirect: { code: number; location: string } | null;
+  } = {
+    statusCode: null,
+    body: null,
+    redirect: null,
+  };
+
+  const res: any = {
+    status(code: number) {
+      record.statusCode = code;
+      return {
+        send(body: any) {
+          record.body = body;
+          return res;
+        },
+      };
+    },
+    redirect(code: number, location: string) {
+      record.redirect = { code, location };
+      return res;
+    },
+  };
+
+  return { res, record };
+}
+
+test("returns 400 when state parameter is missing", async () => {
+  resetSpies();
+  const { res, record } = createMockResponse();
+  const req: any = { query: { code: "abc" } };
+
+  await handler(req, res);
+
+  assert.strictEqual(record.statusCode, 400);
+  assert.strictEqual(record.body, "Missing or invalid state");
+  assert.strictEqual(exchangeCodeForTokensSpy.mock.callCount(), 0);
+  assert.strictEqual(getTokenInfoSpy.mock.callCount(), 0);
+});
+
+test("returns 400 when state is not valid JSON", async () => {
+  resetSpies();
+  const { res, record } = createMockResponse();
+  const req: any = { query: { code: "abc", state: "not-json" } };
+
+  await handler(req, res);
+
+  assert.strictEqual(record.statusCode, 400);
+  assert.strictEqual(record.body, "Missing or invalid state");
+  assert.strictEqual(exchangeCodeForTokensSpy.mock.callCount(), 0);
+  assert.strictEqual(getTokenInfoSpy.mock.callCount(), 0);
+});
+
+test("returns 400 when state omits user", async () => {
+  resetSpies();
+  const { res, record } = createMockResponse();
+  const req: any = { query: { code: "abc", state: JSON.stringify({}) } };
+
+  await handler(req, res);
+
+  assert.strictEqual(record.statusCode, 400);
+  assert.strictEqual(record.body, "Missing or invalid state");
+  assert.strictEqual(exchangeCodeForTokensSpy.mock.callCount(), 0);
+  assert.strictEqual(getTokenInfoSpy.mock.callCount(), 0);
+});

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -1,6 +1,6 @@
 // lib/gmail.ts
-// Assumes Gmail integrations always need offline access refresh tokens; trade-off is consistently
-// generating explicit OAuth params (no Base64 encoding) to simplify callback validation logic.
+// Assumes Gmail OAuth flows always request offline access and inspect token metadata; trade-off is
+// making an extra token info request during callback processing so we persist accurate scopes.
 import { google } from "googleapis";
 
 const CLIENT_ID = process.env.GMAIL_CLIENT_ID || "";
@@ -31,4 +31,9 @@ export async function exchangeCodeForTokens(code: string) {
   const client = createOAuthClient();
   const { tokens } = await client.getToken(code);
   return tokens;
+}
+
+export async function getTokenInfo(accessToken: string) {
+  const client = createOAuthClient();
+  return client.getTokenInfo(accessToken);
 }


### PR DESCRIPTION
## Summary
- parse the Gmail callback state JSON string and fail fast on invalid state payloads
- fetch granted scopes via getTokenInfo, persist tokens with an active status, and clear any reauth flag
- add targeted tests that cover the new state validation behaviour for the Gmail callback handler

## Testing
- npx tsc
- node --test api/gmail/callback.test.js api/inbound/postmark.test.js

------
https://chatgpt.com/codex/tasks/task_b_68d18bc8a2ec83318f2053bee20a6a0b