### PR TITLE
Normalize Gmail merchant payloads and discovery retries

### DIFF
--- a/api/gmail/merchants.ts
+++ b/api/gmail/merchants.ts
@@ -1,20 +1,130 @@
 // api/gmail/merchants.ts
+// Assumes Gmail discovery returns domains or sender ids that can safely backfill display names;
+// trade-off is deriving a best-effort pretty label locally to keep the UI readable without storing
+// additional metadata in Supabase.
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import {
   getAccessToken,
   scanGmailMerchants,
   type MerchantDiscoveryItem,
+  type MerchantDiscoverySource,
 } from "../../lib/gmail-scan.js";
 import { saveApprovedMerchants } from "../../lib/merchants.js";
 import { supabaseAdmin } from "../../lib/supabase-admin.js";
 
-function normalizeMerchantRecord(item: MerchantDiscoveryItem): MerchantDiscoveryItem {
-  return {
-    name: item.name,
-    domain: item.domain.toLowerCase(),
-    est_count: item.est_count,
-    source: item.source,
-  };
+interface NormalizedMerchant {
+  id: string;
+  name: string;
+  est_count?: number;
+  source?: MerchantDiscoverySource;
+}
+
+type MerchantInput =
+  | MerchantDiscoveryItem
+  | string
+  | {
+      id?: string | null;
+      domain?: string | null;
+      name?: string | null;
+      est_count?: number | null;
+      source?: string | null;
+    };
+
+function prettyNameFromId(id: string): string {
+  const trimmed = id.trim().toLowerCase();
+  if (!trimmed) return id;
+  const withoutTld = trimmed.replace(/\.(com|net|org|co|io|store|shop)$/i, "");
+  const segments = withoutTld.split(".");
+  const primary = segments[0] || trimmed;
+  return primary
+    .split(/[-_]/)
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : ""))
+    .filter(Boolean)
+    .join(" ") || id;
+}
+
+function normalizeMerchants(items: MerchantInput[]): NormalizedMerchant[] {
+  const deduped = new Map<string, NormalizedMerchant>();
+  for (const entry of items) {
+    if (!entry) continue;
+    let id: string | null = null;
+    let name: string | null = null;
+    let estCount: number | null = null;
+    let source: MerchantDiscoverySource | undefined;
+
+    if (typeof entry === "string") {
+      id = entry;
+    } else {
+      const candidate: any = entry;
+      if (typeof candidate.id === "string") {
+        id = candidate.id;
+      } else if (typeof candidate.domain === "string") {
+        id = candidate.domain;
+      }
+      if (typeof candidate.name === "string") name = candidate.name;
+      if (typeof candidate.est_count === "number" && Number.isFinite(candidate.est_count)) {
+        estCount = candidate.est_count;
+      }
+      if (candidate.source === "smartlabel" || candidate.source === "heuristic") {
+        source = candidate.source;
+      }
+    }
+
+    if (!id) continue;
+    const normalizedId = id.trim().toLowerCase();
+    if (!normalizedId) continue;
+
+    const displayName = (name || "").trim() || prettyNameFromId(normalizedId);
+    const existing = deduped.get(normalizedId);
+    if (existing) {
+      // Merge duplicates so domains stay unique while preserving count and best source.
+      if (typeof estCount === "number") {
+        const current = existing.est_count ?? 0;
+        existing.est_count = current + estCount;
+      }
+      if (!existing.name && displayName) {
+        existing.name = displayName;
+      }
+      if (source === "smartlabel" && existing.source !== "smartlabel") {
+        existing.source = "smartlabel";
+      } else if (!existing.source && source) {
+        existing.source = source;
+      }
+      continue;
+    }
+
+    const record: NormalizedMerchant = {
+      id: normalizedId,
+      name: displayName,
+    };
+    if (typeof estCount === "number") record.est_count = estCount;
+    if (source) record.source = source;
+    deduped.set(normalizedId, record);
+  }
+
+  return Array.from(deduped.values());
+}
+
+function normalizeMerchantIds(values: any[]): string[] {
+  const ids = new Set<string>();
+  for (const value of values) {
+    if (!value) continue;
+    let id: string | null = null;
+    if (typeof value === "string") {
+      id = value;
+    } else if (typeof value === "object") {
+      const candidate: any = value;
+      if (typeof candidate.id === "string") {
+        id = candidate.id;
+      } else if (typeof candidate.domain === "string") {
+        id = candidate.domain;
+      }
+    }
+    if (!id) continue;
+    const normalized = id.trim().toLowerCase();
+    if (normalized) ids.add(normalized);
+  }
+  return Array.from(ids);
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -33,14 +143,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
 
       const { merchants } = await scanGmailMerchants(user, tokens);
-
-      const normalized = merchants.map((item) => normalizeMerchantRecord(item));
+      const normalized = normalizeMerchants(merchants);
 
       await supabaseAdmin.from("auth_merchants").delete().eq("user_id", user);
       if (normalized.length > 0) {
         const payload = normalized.map((item) => ({
           user_id: user,
-          merchant: item.domain,
+          merchant: item.id,
           est_count: item.est_count,
           source: item.source,
         }));
@@ -59,7 +168,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(400).json({ ok: false, error: "missing user or merchants" });
       }
 
-      await saveApprovedMerchants(user, merchants);
+      const merchantIds = normalizeMerchantIds(merchants);
+      await saveApprovedMerchants(user, merchantIds);
       return res.status(200).json({ ok: true });
     }
 

--- a/lib/retry.ts
+++ b/lib/retry.ts
@@ -1,3 +1,50 @@
+// lib/retry.ts
+// Assumes HTTP/Gmail clients surface transient failures via status codes or Node.js error codes;
+// trade-off is relying on generic heuristics instead of client-specific logic, which keeps retry
+// behavior consistent across callers while still covering common flaky network scenarios.
+
+const RETRIABLE_SYSTEM_CODES = new Set([
+  "EBUSY",
+  "EAI_AGAIN",
+  "ENOTFOUND",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNABORTED",
+  "EPIPE",
+  "EPROTO",
+  "ECONNREFUSED",
+]);
+
+function resolveStatus(err: any): number | null {
+  const statusLike = err?.response?.status ?? err?.status ?? err?.statusCode;
+  if (typeof statusLike === "number") return statusLike;
+  const parsed = Number.parseInt(statusLike, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resolveSystemCode(err: any): string | null {
+  const code = err?.code ?? err?.cause?.code ?? err?.error?.code;
+  return typeof code === "string" ? code : null;
+}
+
+function getRetryReason(err: any): string | null {
+  const status = resolveStatus(err);
+  if (status === 429) return "rate_limit";
+  if (typeof status === "number" && status >= 500 && status < 600) {
+    return `http_${status}`;
+  }
+
+  const code = resolveSystemCode(err);
+  if (code && RETRIABLE_SYSTEM_CODES.has(code)) {
+    return `sys_${code}`;
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function withRetry<T>(
   fn: () => Promise<T>,
   description: string,
@@ -10,24 +57,39 @@ export async function withRetry<T>(
       return await fn();
     } catch (err: any) {
       lastErr = err;
-      const status = err?.code || err?.response?.status;
-      // Retry on rate limit or server errors
-      if (status === 429 || (status && status >= 500 && status < 600)) {
-        const delay = Math.pow(2, attempt) * 1000;
-        console.warn(
-          `${description} failed with status ${status}. Retry ${attempt + 1}/${maxAttempts} in ${delay}ms`
-        );
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        attempt++;
+      const reason = getRetryReason(err);
+      const hasMoreAttempts = attempt < maxAttempts - 1;
+      if (reason && hasMoreAttempts) {
+        const baseDelay = Math.min(1000 * 2 ** attempt, 10_000);
+        const jitter = Math.random() * 250;
+        const delay = baseDelay + jitter;
+        console.warn("[retry] transient failure", {
+          description,
+          attempt: attempt + 1,
+          maxAttempts,
+          reason,
+          delay_ms: Math.round(delay),
+        });
+        await sleep(delay);
+        attempt += 1;
         continue;
       }
-      console.error(`${description} failed with non-retryable error`, err);
+
+      console.error("[retry] non-retryable failure", {
+        description,
+        attempt: attempt + 1,
+        maxAttempts,
+        reason,
+        error: err,
+      });
       throw err;
     }
   }
-  console.error(
-    `${description} failed after ${maxAttempts} attempts`,
-    lastErr
-  );
+
+  console.error("[retry] exhausted attempts", {
+    description,
+    attempts: maxAttempts,
+    error: lastErr,
+  });
   throw lastErr;
 }


### PR DESCRIPTION
## Summary
- normalize Gmail merchant responses to stable `{id, name}` payloads and persist ids in Supabase
- render merchants UI with readable labels and send merchant ids on save
- broaden retry helper to cover DNS/socket errors and throttle metadata fetch concurrency during discovery

## Testing
- `npx tsc --noEmit`

## Files
- `api/gmail/merchants.ts`: normalize discovery results, dedupe by id, and persist string ids
- `api/gmail/merchants-ui.ts`: render merchant names and post id lists from the UI
- `lib/retry.ts`: add system error retries with jittered exponential backoff
- `lib/gmail-scan.ts`: expose merchant id shape and limit metadata fetch concurrency with optional `GMAIL_FETCH_CONCURRENCY`


------
https://chatgpt.com/codex/tasks/task_b_68d1a207035c8331842969c82fadddbb