### PR TITLE
Adjust Gmail ingest flow to use approved merchants

### DIFF
--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -1,13 +1,18 @@
 // lib/supabase-admin.ts
+// Assumes runtime always supplies service role credentials for privileged writes;
+// trade-off is failing fast during init instead of attempting degraded anon access.
 import { createClient } from "@supabase/supabase-js";
 
 const url = process.env.SUPABASE_URL;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url) {
+  throw new Error("SUPABASE_URL not set – admin writes will fail");
+}
 
-if (!url || !serviceKey) {
-  throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY env vars.");
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceKey) {
+  throw new Error("SUPABASE_SERVICE_ROLE_KEY not set – admin writes will fail");
 }
 
 export const supabaseAdmin = createClient(url, serviceKey, {
-  auth: { persistSession: false, autoRefreshToken: false }
+  auth: { persistSession: false, autoRefreshToken: false },
 });


### PR DESCRIPTION
## Summary
- lib/supabase-admin.ts: require the Supabase service role key to be present at init so admin writes cannot silently downgrade
- api/gmail/merchants.ts: surface Supabase errors when persisting discovery results to auth_merchants
- api/gmail/ingest.ts: load approved merchants before falling back to discoveries, add logging around Supabase writes, and handle empty selections with a 400
- api/gmail/merchants-ui.ts: trigger ingestion immediately after saving selections and show a client-side scanning status

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68d1b606c858833182adf1289052b986