### PR TITLE
Use total cents for Gmail receipt upserts

### DIFF
--- a/lib/__tests__/receipt-dedupe.test.ts
+++ b/lib/__tests__/receipt-dedupe.test.ts
@@ -1,6 +1,7 @@
 // lib/__tests__/receipt-dedupe.test.ts
 // Assumes jest runs via ts-jest in ESM mode so we can exercise normalization logic; trade-off is
-// the extra dev dependency weight to assert canonicalization stays stable for ingestion dedupe keys.
+// the extra dev dependency weight to assert canonicalization stays stable for ingestion dedupe keys
+// while trusting ingestion to scale totals into minor units before they reach this helper.
 
 import { canonicalizeReceipt, makeDedupeKey } from "../receipt-dedupe.js";
 
@@ -12,7 +13,7 @@ describe("canonicalizeReceipt", () => {
       order_id: "  ABC-123  ",
       purchase_date: "2024-04-15T12:00:00Z",
       currency: "usd",
-      total_amount: "$1,234.56",
+      total_cents: " $1,234.56 ",
     });
 
     expect(canonical).toBe("user-123|bestbuy.com|ABC-123|2024-04-15|USD|123456");
@@ -25,7 +26,7 @@ describe("canonicalizeReceipt", () => {
       order_id: "JP-1",
       purchase_date: "2024-01-01",
       currency: "jpy",
-      total_amount: 5000,
+      total_cents: 5000,
     });
 
     const bhd = canonicalizeReceipt({
@@ -34,7 +35,7 @@ describe("canonicalizeReceipt", () => {
       order_id: "BH-1",
       purchase_date: "2024-01-01",
       currency: "BHD",
-      total_amount: 12.345,
+      total_cents: 12345,
     });
 
     expect(jpy.endsWith("|JPY|5000")).toBe(true);
@@ -50,7 +51,7 @@ describe("makeDedupeKey", () => {
       order_id: "XYZ",
       purchase_date: "2024-05-01",
       currency: "usd",
-      total_amount: "49.99",
+      total_cents: "4999",
     });
 
     const second = makeDedupeKey({
@@ -59,7 +60,7 @@ describe("makeDedupeKey", () => {
       order_id: " XYZ ",
       purchase_date: "2024-05-01T08:00:00-04:00",
       currency: "USD",
-      total_amount: 49.99,
+      total_cents: 4999,
     });
 
     expect(first).toBe(second);


### PR DESCRIPTION
## Summary
- convert Gmail ingest to compute currency-aware `total_cents`, drop the unused `total_amount` column in receipts upserts, and keep dedupe keys aligned
- simplify the receipt dedupe helper to hash `total_cents` inputs and rely on ingestion for currency scaling, with tests updated for the new contract

## File Overview
- `api/gmail/ingest.ts`: convert parser totals into minor units, accept either `total_cents` or `total_amount`, and upsert receipts with the correct schema column
- `lib/receipt-dedupe.ts`: canonicalize receipts using `total_cents` inputs and lighten normalization now that cents arrive pre-scaled
- `lib/__tests__/receipt-dedupe.test.ts`: adjust coverage to reflect the new `total_cents` behavior

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: script not defined in repo)*
- `npm run lint` *(fails: script not defined in repo)*
- `npm test` *(fails: jest binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d1e070dda88331806632719c429b03