### PR TITLE
Implement Gmail token refresh and merchant discovery API

### DIFF
--- a/api/gmail/callback.ts
+++ b/api/gmail/callback.ts
@@ -1,97 +1,111 @@
-// api/gmail/callback.ts
-// Assumes Gmail OAuth state arrives as plain JSON and Supabase retains prior refresh tokens; trade-off
-// is rejecting tampered state with a 400 while doing an extra read when Google omits refresh tokens so
-// reauthorized users keep working.
+// PATH: api/gmail/callback.ts
+// Assumes Google OAuth state arrives as base64url JSON containing the user id; trade-off is decoding
+// and validating the payload manually to keep the handler independent of external frameworks while
+// persisting refresh/access tokens atomically in Supabase.
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { exchangeCodeForTokens, getTokenInfo } from "../../lib/gmail.js";
+import { exchangeCodeForTokens } from "../../lib/gmail.js";
 import { supabaseAdmin } from "../../lib/supabase-admin.js";
+
+function decodeState(rawState: string): { user: string } | null {
+  try {
+    const json = Buffer.from(rawState, "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as any).user === "string" &&
+      (parsed as any).user.trim()
+    ) {
+      return { user: (parsed as any).user.trim() };
+    }
+  } catch {
+    // ignore decode errors and return null
+  }
+  return null;
+}
+
+function extractScopes(raw: unknown): string[] {
+  if (!raw) return [];
+  if (typeof raw === "string") {
+    return raw
+      .split(/\s+/)
+      .map((scope) => scope.trim())
+      .filter((scope) => scope.length > 0);
+  }
+  if (Array.isArray(raw)) {
+    return Array.from(
+      new Set(
+        raw
+          .map((scope) => (typeof scope === "string" ? scope.trim() : ""))
+          .filter((scope): scope is string => scope.length > 0)
+      )
+    );
+  }
+  return [];
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const code = typeof req.query.code === "string" ? req.query.code : "";
-  const rawState = req.query.state;
-  if (typeof rawState !== "string" || !rawState.trim()) {
+  const rawState = typeof req.query.state === "string" ? req.query.state : "";
+
+  if (!rawState) {
     return res.status(400).send("Missing or invalid state");
   }
 
-  let user = "";
-  try {
-    // State payload is JSON encoded upstream; reject anything else so we surface tampering quickly.
-    const parsedState = JSON.parse(rawState);
-    if (
-      !parsedState ||
-      typeof parsedState !== "object" ||
-      typeof (parsedState as any).user !== "string" ||
-      !(parsedState as any).user.trim()
-    ) {
-      return res.status(400).send("Missing or invalid state");
-    }
-    user = (parsedState as any).user.trim();
-  } catch {
+  const state = decodeState(rawState);
+  if (!state?.user) {
     return res.status(400).send("Missing or invalid state");
   }
 
+  if (!code) {
+    return res.status(400).send("Missing authorization code");
+  }
+
+  const user = state.user;
+
   try {
-    const maskedUser =
-      user.length > 8 ? `${user.slice(0, 4)}…${user.slice(-2)}` : user || "unknown";
-
-    if (!code) throw new Error("missing code");
-
     const tokens = await exchangeCodeForTokens(code);
-    const expires = tokens.expiry_date ? new Date(tokens.expiry_date).toISOString() : null;
+    const refreshToken =
+      typeof tokens.refresh_token === "string" && tokens.refresh_token.trim().length > 0
+        ? tokens.refresh_token.trim()
+        : null;
+    const accessToken =
+      typeof tokens.access_token === "string" && tokens.access_token.trim().length > 0
+        ? tokens.access_token.trim()
+        : null;
 
-    // Preserve an existing refresh token if Google does not return one on this callback.
-    let refreshToken = tokens.refresh_token || null;
-    if (!refreshToken) {
+    let finalRefreshToken = refreshToken;
+    if (!finalRefreshToken) {
       const { data: existingTokenRow, error: existingTokenError } = await supabaseAdmin
         .from("gmail_tokens")
         .select("refresh_token")
         .eq("user_id", user)
         .maybeSingle();
       if (existingTokenError) {
-        console.error("[gmail] failed to load existing refresh token", {
-          error: existingTokenError,
-          user: maskedUser,
-        });
+        throw existingTokenError;
       }
       if (existingTokenRow?.refresh_token) {
-        refreshToken = existingTokenRow.refresh_token as string;
+        finalRefreshToken = existingTokenRow.refresh_token as string;
       }
     }
 
-    if (!refreshToken) {
-      // Without a refresh token we cannot sustain access, so fail fast and surface an error to the UI.
+    if (!finalRefreshToken) {
       throw new Error("missing refresh token");
     }
 
-    let grantedScopes: string[] = [];
-    if (tokens.access_token) {
-      try {
-        const info = await getTokenInfo(tokens.access_token);
-        const scopes = Array.isArray(info?.scopes)
-          ? info.scopes
-          : typeof (info as any)?.scope === "string"
-          ? (info as any).scope.split(/\s+/)
-          : [];
-        grantedScopes = Array.from(
-          new Set(
-            scopes
-              .map((scope: any) => (typeof scope === "string" ? scope.trim() : ""))
-              .filter((scope: string) => scope.length > 0)
-          )
-        );
-      } catch (err) {
-        console.warn("[gmail] failed to fetch granted scopes during callback", err);
-      }
-    }
+    const expiresIn = typeof tokens.expires_in === "number" ? tokens.expires_in : null;
+    const expiresAt =
+      expiresIn && expiresIn > 0 ? new Date(Date.now() + expiresIn * 1000).toISOString() : null;
+    const grantedScopes = extractScopes(tokens.scope);
 
     const { error: upsertError } = await supabaseAdmin
       .from("gmail_tokens")
       .upsert(
         {
           user_id: user,
-          refresh_token: refreshToken,
-          access_token: tokens.access_token,
-          access_token_expires_at: expires,
+          refresh_token: finalRefreshToken,
+          access_token: accessToken,
+          access_token_expires_at: expiresAt,
           granted_scopes: grantedScopes,
           status: "active",
           reauth_required: false,
@@ -101,13 +115,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     if (upsertError) {
       throw upsertError;
-    }
-
-    if (grantedScopes.length > 0) {
-      console.info("[gmail] linked user scopes", {
-        user: maskedUser,
-        scopes: grantedScopes,
-      });
     }
 
     return res.redirect(302, `/api/gmail/merchants-ui?user=${encodeURIComponent(user)}`);

--- a/lib/__tests__/gmail.test.ts
+++ b/lib/__tests__/gmail.test.ts
@@ -1,0 +1,100 @@
+// PATH: lib/__tests__/gmail.test.ts
+// Assumes Gmail helper functions can run with mocked Supabase/fetch; trade-off is manually wiring
+// stubs for each call sequence to verify refresh flows without pulling in heavier mock frameworks.
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+describe("ensureAccessToken", () => {
+  const ORIGINAL_FETCH = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.SUPABASE_URL = "http://example.com";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service";
+    process.env.GMAIL_CLIENT_ID = "client";
+    process.env.GMAIL_CLIENT_SECRET = "secret";
+    process.env.GMAIL_REDIRECT_URI = "https://example.com/callback";
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  test("returns cached token when not expired", async () => {
+    globalThis.fetch = jest.fn(() => Promise.resolve(new Response())) as any;
+    const { ensureAccessToken } = await import("../gmail.js");
+    const { supabaseAdmin } = await import("../supabase-admin.js");
+
+    (supabaseAdmin as any).from = () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: {
+              refresh_token: "refresh",
+              access_token: "token",
+              access_token_expires_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+            },
+            error: null,
+          }),
+        }),
+      }),
+      update: () => ({
+        eq: () => Promise.resolve({ error: null }),
+      }),
+    });
+
+    const result = await ensureAccessToken("user-1");
+    expect(result.accessToken).toBe("token");
+    expect((globalThis.fetch as any)).not.toHaveBeenCalled();
+  });
+
+  test("refreshes when expired", async () => {
+    const fetchMock = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ access_token: "new-token", expires_in: 3600, scope: "scope1 scope2" }),
+      text: async () => "",
+    }));
+    globalThis.fetch = fetchMock as any;
+
+    const { ensureAccessToken } = await import("../gmail.js");
+    const { supabaseAdmin } = await import("../supabase-admin.js");
+
+    const updateSpy = jest.fn().mockReturnValue({ eq: () => Promise.resolve({ error: null }) });
+
+    (supabaseAdmin as any).from = () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: {
+              refresh_token: "refresh",
+              access_token: "old-token",
+              access_token_expires_at: new Date(Date.now() - 60 * 1000).toISOString(),
+            },
+            error: null,
+          }),
+        }),
+      }),
+      update: updateSpy,
+    });
+
+    const result = await ensureAccessToken("user-2");
+    expect(result.accessToken).toBe("new-token");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws reauthorize when refresh token missing", async () => {
+    globalThis.fetch = jest.fn(() => Promise.resolve(new Response())) as any;
+    const { ensureAccessToken, ReauthorizeNeeded } = await import("../gmail.js");
+    const { supabaseAdmin } = await import("../supabase-admin.js");
+
+    (supabaseAdmin as any).from = () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: { refresh_token: null }, error: null }),
+        }),
+      }),
+    });
+
+    await expect(ensureAccessToken("user-3")).rejects.toBeInstanceOf(ReauthorizeNeeded);
+  });
+});

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -1,39 +1,395 @@
-// lib/gmail.ts
-// Assumes Gmail OAuth flows always request offline access and inspect token metadata; trade-off is
-// making an extra token info request during callback processing so we persist accurate scopes.
-import { google } from "googleapis";
+// PATH: lib/gmail.ts
+// Assumes Gmail tokens in Supabase are refreshable with Google OAuth2 refresh grants; trade-off is
+// eagerly refreshing expired tokens and surfacing reauth errors explicitly instead of letting Gmail
+// API calls fail generically, which adds a small amount of read/write overhead per refresh.
+import { getDomain } from "tldts";
+import { supabaseAdmin } from "./supabase-admin.js";
+
+const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const GOOGLE_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
+const GMAIL_API_BASE = "https://gmail.googleapis.com";
+const TOKEN_BUFFER_MS = 60_000; // refresh when expiry is within the next minute.
 
 const CLIENT_ID = process.env.GMAIL_CLIENT_ID || "";
 const CLIENT_SECRET = process.env.GMAIL_CLIENT_SECRET || "";
 const REDIRECT_URI = process.env.GMAIL_REDIRECT_URI || "";
 
-const SCOPES = [
-  "https://www.googleapis.com/auth/gmail.modify",
-  "https://www.googleapis.com/auth/gmail.labels",
-];
-
-export function createOAuthClient() {
-  return new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+if (!CLIENT_ID || !CLIENT_SECRET || !REDIRECT_URI) {
+  throw new Error("Gmail OAuth env vars (GMAIL_CLIENT_ID, SECRET, REDIRECT_URI) must be set");
 }
 
-export function getGmailAuthUrl({ user }: { user: string }): string {
-  const client = createOAuthClient();
-  return client.generateAuthUrl({
-    access_type: "offline",
-    scope: SCOPES,
-    state: JSON.stringify({ user }),
-    prompt: "consent",
-    include_granted_scopes: false,
+export class ReauthorizeNeeded extends Error {
+  constructor(message = "Gmail reauthorization required") {
+    super(message);
+    this.name = "ReauthorizeNeeded";
+  }
+}
+
+type GmailTokenRow = {
+  refresh_token: string | null;
+  access_token: string | null;
+  access_token_expires_at: string | null;
+  granted_scopes?: string[] | null;
+};
+
+interface EnsureAccessTokenOptions {
+  forceRefresh?: boolean;
+}
+
+interface EnsureAccessTokenResult {
+  accessToken: string;
+  expiresAt: string | null;
+}
+
+interface RefreshTokenResult {
+  accessToken: string;
+  expiresAt: string | null;
+  grantedScopes: string[];
+}
+
+function isExpired(expiresAt: string | null): boolean {
+  if (!expiresAt) return true;
+  const expiryTime = Date.parse(expiresAt);
+  if (Number.isNaN(expiryTime)) return true;
+  return expiryTime - TOKEN_BUFFER_MS <= Date.now();
+}
+
+function normalizeScopes(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return Array.from(
+      new Set(
+        value
+          .map((scope) => (typeof scope === "string" ? scope.trim() : ""))
+          .filter((scope): scope is string => scope.length > 0)
+      )
+    );
+  }
+  if (typeof value === "string" && value.trim()) {
+    return value
+      .split(/\s+/)
+      .map((scope) => scope.trim())
+      .filter((scope) => scope.length > 0);
+  }
+  return [];
+}
+
+export async function refreshAccessToken(refreshToken: string): Promise<RefreshTokenResult> {
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+
+  const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: params.toString(),
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  const errorCode = typeof payload?.error === "string" ? payload.error : null;
+
+  if (!response.ok) {
+    if (errorCode === "invalid_grant") {
+      throw new ReauthorizeNeeded("refresh token rejected by Google");
+    }
+    const description =
+      typeof payload?.error_description === "string"
+        ? payload.error_description
+        : "failed to refresh Gmail access token";
+    throw new Error(description);
+  }
+
+  const accessToken = typeof payload?.access_token === "string" ? payload.access_token : "";
+  if (!accessToken) {
+    throw new Error("Google response missing access_token");
+  }
+
+  const expiresInRaw = (payload as any)?.expires_in;
+  const expiresIn =
+    typeof expiresInRaw === "number"
+      ? expiresInRaw
+      : typeof expiresInRaw === "string" && Number.isFinite(Number.parseInt(expiresInRaw, 10))
+      ? Number.parseInt(expiresInRaw, 10)
+      : null;
+  const expiresAt =
+    expiresIn && expiresIn > 0 ? new Date(Date.now() + expiresIn * 1000).toISOString() : null;
+
+  const grantedScopes = normalizeScopes((payload as any)?.scope);
+
+  return { accessToken, expiresAt, grantedScopes };
+}
+
+export async function ensureAccessToken(
+  userId: string,
+  options: EnsureAccessTokenOptions = {}
+): Promise<EnsureAccessTokenResult> {
+  if (!userId || typeof userId !== "string") {
+    throw new Error("userId is required");
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("gmail_tokens")
+    .select("refresh_token, access_token, access_token_expires_at, granted_scopes")
+    .eq("user_id", userId)
+    .maybeSingle<GmailTokenRow>();
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data || !data.refresh_token) {
+    throw new ReauthorizeNeeded("missing refresh token");
+  }
+
+  const hasValidToken =
+    !options.forceRefresh && typeof data.access_token === "string" && data.access_token.length > 0;
+
+  if (hasValidToken && !isExpired(data.access_token_expires_at)) {
+    return { accessToken: data.access_token as string, expiresAt: data.access_token_expires_at };
+  }
+
+  const refreshResult = await refreshAccessToken(data.refresh_token);
+
+  const { error: updateError } = await supabaseAdmin
+    .from("gmail_tokens")
+    .update({
+      access_token: refreshResult.accessToken,
+      access_token_expires_at: refreshResult.expiresAt,
+      granted_scopes: refreshResult.grantedScopes,
+      status: "active",
+      reauth_required: false,
+    })
+    .eq("user_id", userId);
+
+  if (updateError) {
+    throw updateError;
+  }
+
+  return { accessToken: refreshResult.accessToken, expiresAt: refreshResult.expiresAt };
+}
+
+function buildRequestInit(accessToken: string, init?: RequestInit): RequestInit {
+  const headers = new Headers(init?.headers || {});
+  headers.set("Authorization", `Bearer ${accessToken}`);
+  headers.set("Accept", "application/json");
+  return { ...init, headers };
+}
+
+async function performGmailFetch(
+  userId: string,
+  path: string,
+  init?: RequestInit,
+  forceRefresh = false
+): Promise<Response> {
+  const { accessToken } = await ensureAccessToken(userId, { forceRefresh });
+  const response = await fetch(`${GMAIL_API_BASE}${path}`, buildRequestInit(accessToken, init));
+  return response;
+}
+
+export async function gmailFetch(
+  userId: string,
+  path: string,
+  init?: RequestInit
+): Promise<Response> {
+  let response = await performGmailFetch(userId, path, init, false);
+  if (response.status === 401) {
+    response = await performGmailFetch(userId, path, init, true);
+    if (response.status === 401) {
+      throw new ReauthorizeNeeded("Gmail returned 401 after refresh");
+    }
+  }
+  if (!response.ok) {
+    const bodyText = await response.text().catch(() => "");
+    throw new Error(`Gmail request failed (${response.status}): ${bodyText || "no body"}`);
+  }
+  return response;
+}
+
+function extractFromHeader(headers: any[]): string | null {
+  if (!Array.isArray(headers)) return null;
+  for (const header of headers) {
+    if (!header || typeof header !== "object") continue;
+    const name = typeof header.name === "string" ? header.name.toLowerCase() : "";
+    if (name === "from") {
+      const value = typeof header.value === "string" ? header.value.trim() : "";
+      if (value) return value;
+    }
+  }
+  return null;
+}
+
+function parseSender(fromHeader: string): { domain: string | null; merchant: string | null; sample: string } {
+  const sample = fromHeader.trim();
+  const emailMatch = sample.match(/[<\s]([^<>\s]+@[^<>\s]+)>?/);
+  const email = emailMatch ? emailMatch[1].toLowerCase() : null;
+  const rawDomain = email ? email.split("@")[1] || null : null;
+  const domain = rawDomain ? getDomain(rawDomain) || rawDomain : rawDomain;
+  const nameMatch = sample.match(/^(.*?)<[^>]+>/);
+  const displayName = nameMatch ? nameMatch[1].replace(/["']/g, "").trim() : "";
+  const merchant = displayName || (domain ? merchantNameFromDomain(domain) : null);
+  return { domain, merchant, sample };
+}
+
+function merchantNameFromDomain(domain: string): string {
+  const trimmed = domain.replace(/\.(com|net|org|co|io|shop|store)$/gi, "");
+  const primary = trimmed.split(".")[0] || domain;
+  return primary
+    .split(/[-_]/)
+    .map((chunk) => (chunk ? chunk[0].toUpperCase() + chunk.slice(1) : ""))
+    .filter(Boolean)
+    .join(" ") || domain;
+}
+
+interface MerchantSummary {
+  domain: string;
+  merchant: string;
+  count: number;
+  samples: string[];
+}
+
+function aggregateMerchants(records: Array<{ domain: string | null; merchant: string | null; sample: string }>): MerchantSummary[] {
+  const map = new Map<string, MerchantSummary>();
+  for (const record of records) {
+    if (!record.domain) continue;
+    const key = record.domain.toLowerCase();
+    const existing = map.get(key);
+    if (!existing) {
+      map.set(key, {
+        domain: key,
+        merchant: record.merchant || merchantNameFromDomain(key),
+        count: 1,
+        samples: [record.sample],
+      });
+      continue;
+    }
+    existing.count += 1;
+    if (record.merchant && !existing.merchant) {
+      existing.merchant = record.merchant;
+    }
+    if (!existing.samples.includes(record.sample) && existing.samples.length < 5) {
+      existing.samples.push(record.sample);
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.domain.localeCompare(b.domain);
   });
 }
 
-export async function exchangeCodeForTokens(code: string) {
-  const client = createOAuthClient();
-  const { tokens } = await client.getToken(code);
-  return tokens;
+export async function listLikelyMerchants(
+  userId: string,
+  lookbackDays = 90,
+  maxMessages = 50
+): Promise<MerchantSummary[]> {
+  const safeDays = Number.isFinite(lookbackDays) && lookbackDays > 0 ? Math.floor(lookbackDays) : 90;
+  const safeMax = Number.isFinite(maxMessages) && maxMessages > 0 ? Math.min(Math.floor(maxMessages), 500) : 50;
+
+  const query = `newer_than:${safeDays}d -in:spam -in:trash`;
+  const params = new URLSearchParams({
+    maxResults: String(safeMax),
+    q: query,
+  });
+
+  const listResponse = await gmailFetch(
+    userId,
+    `/gmail/v1/users/me/messages?${params.toString()}`,
+    { method: "GET" }
+  );
+  const listPayload = (await listResponse.json()) as any;
+  const messages: Array<{ id: string }> = Array.isArray(listPayload?.messages)
+    ? listPayload.messages.filter((msg: any) => msg && typeof msg.id === "string")
+    : [];
+
+  const results: Array<{ domain: string | null; merchant: string | null; sample: string }> = [];
+
+  for (const message of messages) {
+    try {
+      const detailResponse = await gmailFetch(
+        userId,
+        `/gmail/v1/users/me/messages/${encodeURIComponent(message.id)}?format=metadata&metadataHeaders=From`,
+        { method: "GET" }
+      );
+      const detailPayload = (await detailResponse.json()) as any;
+      const fromHeader = extractFromHeader(detailPayload?.payload?.headers || []);
+      if (!fromHeader) continue;
+      results.push(parseSender(fromHeader));
+    } catch (err) {
+      if (err instanceof ReauthorizeNeeded) {
+        throw err;
+      }
+      console.warn("[gmail] failed to inspect message", {
+        userId: userId ? `${userId.slice(0, 4)}…` : "unknown",
+        messageId: message.id,
+        error: (err as Error)?.message || String(err),
+      });
+    }
+  }
+
+  return aggregateMerchants(results);
 }
 
-export async function getTokenInfo(accessToken: string) {
-  const client = createOAuthClient();
-  return client.getTokenInfo(accessToken);
+export function getGoogleAuthUrl(state: string): string {
+  if (!state || typeof state !== "string") {
+    throw new Error("state is required for Google OAuth");
+  }
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    redirect_uri: REDIRECT_URI,
+    response_type: "code",
+    scope: [
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/userinfo.email",
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "openid",
+    ].join(" "),
+    access_type: "offline",
+    prompt: "consent",
+    include_granted_scopes: "false",
+    state,
+  });
+  return `${GOOGLE_AUTH_ENDPOINT}?${params.toString()}`;
+}
+
+export interface TokenExchangeResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  id_token?: string;
+  token_type?: string;
+}
+
+export async function exchangeCodeForTokens(code: string): Promise<TokenExchangeResponse> {
+  if (!code || typeof code !== "string") {
+    throw new Error("authorization code required");
+  }
+
+  const params = new URLSearchParams({
+    code,
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+    redirect_uri: REDIRECT_URI,
+    grant_type: "authorization_code",
+  });
+
+  const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const bodyText = await response.text().catch(() => "");
+    throw new Error(`token exchange failed (${response.status}): ${bodyText || "no body"}`);
+  }
+
+  const payload = (await response.json()) as TokenExchangeResponse;
+  return payload;
 }


### PR DESCRIPTION
## Summary
- `lib/gmail.ts`: add refresh-token aware Gmail helpers, OAuth URL builder, and merchant discovery utilities.
- `api/gmail/merchants.ts`: support authenticated probes, discovery POST, and legacy merchant persistence with explicit reauth errors.
- `api/gmail/auth.ts`: issue base64url-encoded OAuth state for Gmail linking.
- `api/gmail/callback.ts`: decode new state payloads, persist refreshed tokens, and capture granted scopes.
- `api/connectors/gmail/reauthorize.ts`: reuse the new OAuth URL helper with encoded state.
- `api/gmail/merchants-ui.ts`: call the probe/discovery flow before rendering merchants.
- `api/gmail/callback.test.ts`: adjust tests for base64url state handling.
- `lib/__tests__/gmail.test.ts`: cover token refresh paths with mocked Supabase and fetch.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68e15bf861e88331bd711ec41e19b4e2